### PR TITLE
feat: indexer file location cache; CLI update

### DIFF
--- a/cmd/download.go
+++ b/cmd/download.go
@@ -13,8 +13,11 @@ import (
 
 var (
 	downloadArgs struct {
-		file  string
-		nodes []string
+		file string
+
+		indexer string
+		nodes   []string
+
 		root  string
 		proof bool
 	}
@@ -31,7 +34,7 @@ func init() {
 	downloadCmd.MarkFlagRequired("file")
 
 	downloadCmd.Flags().StringSliceVar(&downloadArgs.nodes, "node", []string{}, "ZeroGStorage storage node URL. Multiple nodes could be specified and separated by comma, e.g. url1,url2,url3")
-	uploadCmd.Flags().StringVar(&uploadArgs.indexer, "indexer", "", "ZeroGStorage indexer URL")
+	downloadCmd.Flags().StringVar(&downloadArgs.indexer, "indexer", "", "ZeroGStorage indexer URL")
 
 	downloadCmd.Flags().StringVar(&downloadArgs.root, "root", "", "Merkle root to download file")
 	downloadCmd.MarkFlagRequired("root")
@@ -41,13 +44,13 @@ func init() {
 }
 
 func download(*cobra.Command, []string) {
-	if uploadArgs.indexer != "" {
-		indexerClient, err := indexer.NewClient(uploadArgs.indexer, indexer.IndexerClientOption{LogOption: common.LogOption{Logger: logrus.StandardLogger()}})
+	if downloadArgs.indexer != "" {
+		indexerClient, err := indexer.NewClient(downloadArgs.indexer, indexer.IndexerClientOption{LogOption: common.LogOption{Logger: logrus.StandardLogger()}})
 		if err != nil {
 			logrus.WithError(err).Fatal("Failed to initialize indexer client")
 		}
 		if err := indexerClient.Download(context.Background(), downloadArgs.root, downloadArgs.file, downloadArgs.proof); err != nil {
-			logrus.WithError(err).Fatal("Failed to download file")
+			logrus.WithError(err).Fatal("Failed to download file from indexer")
 		}
 		return
 	}

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/0glabs/0g-storage-client/common"
-	zg_common "github.com/0glabs/0g-storage-client/common"
 	"github.com/0glabs/0g-storage-client/indexer"
 	"github.com/0glabs/0g-storage-client/node"
 	"github.com/0glabs/0g-storage-client/transfer"
@@ -43,7 +42,7 @@ func init() {
 
 func download(*cobra.Command, []string) {
 	if uploadArgs.indexer != "" {
-		indexerClient, err := indexer.NewClient(uploadArgs.indexer, indexer.IndexerClientOption{LogOption: zg_common.LogOption{Logger: logrus.StandardLogger()}})
+		indexerClient, err := indexer.NewClient(uploadArgs.indexer, indexer.IndexerClientOption{LogOption: common.LogOption{Logger: logrus.StandardLogger()}})
 		if err != nil {
 			logrus.WithError(err).Fatal("Failed to initialize indexer client")
 		}

--- a/cmd/kv_write.go
+++ b/cmd/kv_write.go
@@ -68,7 +68,8 @@ func init() {
 
 	kvWriteCmd.Flags().UintVar(&kvWriteArgs.expectedReplica, "expected-replica", 1, "expected number of replications to kvWrite")
 
-	kvWriteCmd.Flags().BoolVar(&kvWriteArgs.skipTx, "skip-tx", false, "Skip sending the transaction on chain")
+	// note: for KV operations, skip-tx should by default to be false
+	kvWriteCmd.Flags().BoolVar(&kvWriteArgs.skipTx, "skip-tx", false, "Skip sending the transaction on chain if already exists")
 	kvWriteCmd.Flags().BoolVar(&kvWriteArgs.finalityRequired, "finality-required", false, "Wait for file finality on nodes to kvWrite")
 	kvWriteCmd.Flags().UintVar(&kvWriteArgs.taskSize, "task-size", 10, "Number of segments to kvWrite in single rpc request")
 

--- a/cmd/upload.go
+++ b/cmd/upload.go
@@ -59,7 +59,7 @@ func init() {
 
 	uploadCmd.Flags().UintVar(&uploadArgs.expectedReplica, "expected-replica", 1, "expected number of replications to upload")
 
-	uploadCmd.Flags().BoolVar(&uploadArgs.skipTx, "skip-tx", false, "Skip sending the transaction on chain")
+	uploadCmd.Flags().BoolVar(&uploadArgs.skipTx, "skip-tx", true, "Skip sending the transaction on chain if already exists")
 	uploadCmd.Flags().BoolVar(&uploadArgs.finalityRequired, "finality-required", false, "Wait for file finality on nodes to upload")
 	uploadCmd.Flags().UintVar(&uploadArgs.taskSize, "task-size", 10, "Number of segments to upload in single rpc request")
 

--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/hashicorp/go-bexpr v0.1.10 // indirect
 	github.com/hashicorp/golang-lru v0.5.5-0.20210104140557-80c98217689d // indirect
+	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/holiman/bloomfilter/v2 v2.0.3 // indirect
 	github.com/holiman/uint256 v1.2.0 // indirect
 	github.com/huin/goupnp v1.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -235,6 +235,8 @@ github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.5-0.20210104140557-80c98217689d h1:dg1dEPuWpEqDnvIw251EVy4zlP8gWbsGj4BsUKCRpYs=
 github.com/hashicorp/golang-lru v0.5.5-0.20210104140557-80c98217689d/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
+github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
+github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/holiman/bloomfilter/v2 v2.0.3 h1:73e0e/V0tCydx14a0SCYS/EWCxgwLZ18CZcZKVu0fao=
 github.com/holiman/bloomfilter/v2 v2.0.3/go.mod h1:zpoh+gs7qcpqrHr3dB55AMiJwo0iURXE7ZOP9L9hSkA=
 github.com/holiman/uint256 v1.2.0 h1:gpSYcPLWGv4sG43I2mVLiDZCNDh/EpGjSk8tmtxitHM=

--- a/indexer/api.go
+++ b/indexer/api.go
@@ -3,6 +3,7 @@ package indexer
 import (
 	"context"
 
+	"github.com/0glabs/0g-storage-client/common/shard"
 	"github.com/pkg/errors"
 )
 
@@ -35,4 +36,9 @@ func (api *IndexerApi) GetShardedNodes(ctx context.Context) (ShardedNodes, error
 // GetNodeLocations return IP locations of all nodes.
 func (api *IndexerApi) GetNodeLocations(ctx context.Context) (map[string]*IPLocation, error) {
 	return defaultIPLocationManager.All(), nil
+}
+
+// GetFileLocations return locations info of given file.
+func (api *IndexerApi) GetFileLocations(ctx context.Context, txSeq uint64) (locations []*shard.ShardedNode, err error) {
+	return defaultFileLocationCache.GetFileLocations(ctx, txSeq)
 }

--- a/indexer/api.go
+++ b/indexer/api.go
@@ -2,8 +2,10 @@ package indexer
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/0glabs/0g-storage-client/common/shard"
+	eth_common "github.com/ethereum/go-ethereum/common"
 	"github.com/pkg/errors"
 )
 
@@ -39,6 +41,23 @@ func (api *IndexerApi) GetNodeLocations(ctx context.Context) (map[string]*IPLoca
 }
 
 // GetFileLocations return locations info of given file.
-func (api *IndexerApi) GetFileLocations(ctx context.Context, txSeq uint64) (locations []*shard.ShardedNode, err error) {
+func (api *IndexerApi) GetFileLocations(ctx context.Context, root string) (locations []*shard.ShardedNode, err error) {
+	// find corresponding tx sequence
+	hash := eth_common.HexToHash(root)
+	trustedClients := defaultNodeManager.TrustedClients()
+	var txSeq uint64
+	found := false
+	for _, client := range trustedClients {
+		info, err := client.GetFileInfo(ctx, hash)
+		if err != nil || info == nil {
+			continue
+		}
+		txSeq = info.Tx.Seq
+		found = true
+		break
+	}
+	if !found {
+		return nil, fmt.Errorf("file not found")
+	}
 	return defaultFileLocationCache.GetFileLocations(ctx, txSeq)
 }

--- a/indexer/client.go
+++ b/indexer/client.go
@@ -61,6 +61,12 @@ func (c *Client) GetNodeLocations(ctx context.Context) (locations map[string]*IP
 	return
 }
 
+// GetFileLocations return locations info of given file.
+func (c *Client) GetFileLocations(ctx context.Context, txSeq uint64) (locations []*shard.ShardedNode, err error) {
+	err = c.Provider.CallContext(ctx, &locations, "indexer_getFileLocations")
+	return
+}
+
 // SelectNodes get node list from indexer service and select a subset of it, which is sufficient to store expected number of replications.
 func (c *Client) SelectNodes(ctx context.Context, expectedReplica uint) ([]*node.ZgsClient, error) {
 	nodes, err := c.GetShardedNodes(ctx)

--- a/indexer/client.go
+++ b/indexer/client.go
@@ -3,8 +3,10 @@ package indexer
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/0glabs/0g-storage-client/common"
+	zg_common "github.com/0glabs/0g-storage-client/common"
 	"github.com/0glabs/0g-storage-client/common/shard"
 	"github.com/0glabs/0g-storage-client/contract"
 	"github.com/0glabs/0g-storage-client/core"
@@ -14,6 +16,7 @@ import (
 	"github.com/openweb3/go-rpc-provider/interfaces"
 	providers "github.com/openweb3/go-rpc-provider/provider_wrapper"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 // Requires `Client` implements the `Interface` interface.
@@ -23,6 +26,7 @@ var _ Interface = (*Client)(nil)
 type Client struct {
 	interfaces.Provider
 	option IndexerClientOption
+	logger *logrus.Logger
 }
 
 // IndexerClientOption indexer client option
@@ -46,6 +50,7 @@ func NewClient(url string, option ...IndexerClientOption) (*Client, error) {
 	return &Client{
 		Provider: provider,
 		option:   opt,
+		logger:   zg_common.NewLogger(opt.LogOption),
 	}, nil
 }
 
@@ -69,11 +74,34 @@ func (c *Client) GetFileLocations(ctx context.Context, txSeq uint64) (locations 
 
 // SelectNodes get node list from indexer service and select a subset of it, which is sufficient to store expected number of replications.
 func (c *Client) SelectNodes(ctx context.Context, expectedReplica uint) ([]*node.ZgsClient, error) {
-	nodes, err := c.GetShardedNodes(ctx)
+	allNodes, err := c.GetShardedNodes(ctx)
 	if err != nil {
 		return nil, err
 	}
-	trusted, ok := shard.Select(nodes.Trusted, expectedReplica)
+	// filter out nodes unable to connect
+	nodes := make([]*shard.ShardedNode, 0)
+	for _, shardedNode := range allNodes.Trusted {
+		client, err := node.NewZgsClient(shardedNode.URL, c.option.ProviderOption)
+		if err != nil {
+			c.logger.Debugf("failed to initialize client of node %v, dropped.", shardedNode.URL)
+			continue
+		}
+		defer client.Close()
+		start := time.Now()
+		config, err := client.GetShardConfig(ctx)
+		if err != nil || !config.IsValid() {
+			c.logger.Debugf("failed to get shard config of node %v, dropped.", shardedNode.URL)
+			continue
+		}
+
+		nodes = append(nodes, &shard.ShardedNode{
+			URL:     shardedNode.URL,
+			Config:  config,
+			Latency: time.Since(start).Milliseconds(),
+		})
+	}
+	// select proper subset
+	trusted, ok := shard.Select(nodes, expectedReplica)
 	if !ok {
 		return nil, fmt.Errorf("cannot select a subset from the returned nodes that meets the replication requirement")
 	}

--- a/indexer/file_location_cache.go
+++ b/indexer/file_location_cache.go
@@ -1,0 +1,155 @@
+package indexer
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/0glabs/0g-storage-client/common/shard"
+	"github.com/0glabs/0g-storage-client/node"
+	"github.com/hashicorp/golang-lru/v2/expirable"
+	"github.com/pkg/errors"
+)
+
+const defaultFindFileCooldown = time.Minute * 60
+const defaultDiscoveredURLRetryInterval = time.Minute * 10
+const defaultSuccessCallLifetime = time.Minute * 10
+
+type FileLocationCacheConfig struct {
+	CacheSize     int
+	Expiry        time.Duration
+	DiscoveryNode string
+}
+
+type successCall struct {
+	node *shard.ShardedNode
+	ts   time.Time
+}
+
+type FileLocationCache struct {
+	cache             *expirable.LRU[uint64, []*shard.ShardedNode]
+	latestFindFile    sync.Map // tx seq -> time.Time
+	latestFailedCall  sync.Map // url -> time.Time
+	latestSuccessCall sync.Map // url -> successCall
+	discoverNode      *node.AdminClient
+}
+
+var defaultFileLocationCache FileLocationCache
+
+func InitFileLocationCache(config FileLocationCacheConfig) (closable func(), err error) {
+	if len(config.DiscoveryNode) > 0 {
+		if defaultFileLocationCache.discoverNode, err = node.NewAdminClient(config.DiscoveryNode, defaultZgsClientOpt); err != nil {
+			return nil, errors.WithMessage(err, "Failed to create admin client to discover peers")
+		}
+	}
+	defaultFileLocationCache.cache = expirable.NewLRU[uint64, []*shard.ShardedNode](config.CacheSize, nil, config.Expiry)
+	return defaultFileLocationCache.close, nil
+}
+
+func (c *FileLocationCache) close() {
+	if c.discoverNode != nil {
+		c.discoverNode.Close()
+	}
+}
+
+func (c *FileLocationCache) GetFileLocations(ctx context.Context, txSeq uint64) ([]*shard.ShardedNode, error) {
+	if nodes, ok := c.cache.Get(txSeq); ok {
+		if _, covered := shard.Select(nodes, 1); covered {
+			return nodes, nil
+		}
+	}
+	var nodes []*shard.ShardedNode
+	// fetch from trusted
+	selected := make(map[string]struct{})
+	trusted := defaultNodeManager.TrustedClients()
+	for _, v := range trusted {
+		start := time.Now()
+		fileInfo, err := v.GetFileInfoByTxSeq(ctx, txSeq)
+		if err != nil || !fileInfo.Finalized {
+			continue
+		}
+		config, err := v.GetShardConfig(context.Background())
+		if err != nil || !config.IsValid() {
+			continue
+		}
+		nodes = append(nodes, &shard.ShardedNode{
+			URL:     v.URL(),
+			Config:  config,
+			Latency: time.Since(start).Milliseconds(),
+		})
+		selected[v.URL()] = struct{}{}
+	}
+	if _, covered := shard.Select(nodes, 1); covered {
+		return nodes, nil
+	}
+	// trusted nodes do not hold all shards of the file, try to find file
+	if c.discoverNode != nil {
+		locations, err := c.discoverNode.GetFileLocation(ctx, txSeq, false)
+		if err != nil {
+			return nil, err
+		}
+		for _, location := range locations {
+			url := fmt.Sprintf("http://%v:5678", location.Ip)
+			if _, ok := selected[url]; ok {
+				continue
+			}
+			if val, ok := c.latestSuccessCall.Load(url); ok {
+				call := val.(successCall)
+				if time.Since(call.ts) < defaultSuccessCallLifetime {
+					nodes = append(nodes, call.node)
+					continue
+				}
+			}
+			if val, ok := c.latestFailedCall.Load(url); ok {
+				if time.Since(val.(time.Time)) < defaultDiscoveredURLRetryInterval {
+					continue
+				}
+			}
+			zgsClient, err := node.NewZgsClient(url, defaultZgsClientOpt)
+			if err != nil {
+				continue
+			}
+			defer zgsClient.Close()
+			fileInfo, err := zgsClient.GetFileInfoByTxSeq(ctx, txSeq)
+			if err != nil {
+				c.latestFailedCall.Store(url, time.Now())
+				continue
+			}
+			if !fileInfo.Finalized {
+				continue
+			}
+			start := time.Now()
+			config, err := zgsClient.GetShardConfig(context.Background())
+			if err != nil {
+				c.latestFailedCall.Store(url, time.Now())
+				continue
+			}
+			if !config.IsValid() {
+				continue
+			}
+			call := successCall{
+				node: &shard.ShardedNode{
+					URL:     url,
+					Config:  config,
+					Latency: time.Since(start).Milliseconds(),
+				},
+				ts: time.Now(),
+			}
+			nodes = append(nodes, call.node)
+			c.latestSuccessCall.Store(url, call)
+			selected[url] = struct{}{}
+		}
+		if _, covered := shard.Select(nodes, 1); covered {
+			return nodes, nil
+		}
+		if val, ok := c.latestFindFile.Load(txSeq); ok {
+			if time.Since(val.(time.Time)) < defaultFindFileCooldown {
+				return nil, nil
+			}
+		}
+		c.discoverNode.FindFile(ctx, txSeq)
+		c.latestFindFile.Store(txSeq, time.Now())
+	}
+	return nil, nil
+}

--- a/indexer/node_manager.go
+++ b/indexer/node_manager.go
@@ -60,14 +60,19 @@ func InitDefaultNodeManager(config NodeManagerConfig) (closable func(), err erro
 	return defaultNodeManager.close, nil
 }
 
-// Trusted returns trusted sharded nodes.
-func (nm *NodeManager) Trusted() ([]*shard.ShardedNode, error) {
+// TrustedClients returns trusted clients.
+func (nm *NodeManager) TrustedClients() []*node.ZgsClient {
 	var clients []*node.ZgsClient
-
 	nm.trusted.Range(func(key, value any) bool {
 		clients = append(clients, value.(*node.ZgsClient))
 		return true
 	})
+	return clients
+}
+
+// Trusted returns trusted sharded nodes.
+func (nm *NodeManager) Trusted() ([]*shard.ShardedNode, error) {
+	clients := nm.TrustedClients()
 
 	var nodes []*shard.ShardedNode
 

--- a/indexer/types.go
+++ b/indexer/types.go
@@ -21,5 +21,5 @@ type Interface interface {
 
 	GetNodeLocations(ctx context.Context) (map[string]*IPLocation, error)
 
-	GetFileLocations(ctx context.Context, txSeq uint64) ([]*shard.ShardedNode, error)
+	GetFileLocations(ctx context.Context, root string) ([]*shard.ShardedNode, error)
 }

--- a/indexer/types.go
+++ b/indexer/types.go
@@ -11,8 +11,15 @@ type ShardedNodes struct {
 	Discovered []*shard.ShardedNode `json:"discovered"`
 }
 
+type FileLocation struct {
+	Url         string            `json:"url"`
+	ShardConfig shard.ShardConfig `json:"shardConfig"`
+}
+
 type Interface interface {
 	GetShardedNodes(ctx context.Context) (ShardedNodes, error)
 
 	GetNodeLocations(ctx context.Context) (map[string]*IPLocation, error)
+
+	GetFileLocations(ctx context.Context, txSeq uint64) ([]*shard.ShardedNode, error)
 }

--- a/node/client_admin.go
+++ b/node/client_admin.go
@@ -32,6 +32,12 @@ func NewAdminClient(url string, option ...providers.Option) (*AdminClient, error
 	return &AdminClient{client}, nil
 }
 
+// FindFile Call find_file to update file location cache
+func (c *AdminClient) FindFile(ctx context.Context, txSeq uint64) (ret int, err error) {
+	err = c.provider.CallContext(ctx, &ret, "admin_findFile", txSeq)
+	return
+}
+
 // Shutdown Call admin_shutdown to shutdown the node.
 func (c *AdminClient) Shutdown(ctx context.Context) (ret int, err error) {
 	err = c.provider.CallContext(ctx, &ret, "admin_shutdown")
@@ -82,5 +88,11 @@ func (c *AdminClient) GetNetworkInfo(ctx context.Context) (info NetworkInfo, err
 // GetPeers Call admin_getPeers to retrieve all discovered network peers.
 func (c *AdminClient) GetPeers(ctx context.Context) (peers map[string]*PeerInfo, err error) {
 	err = c.provider.CallContext(ctx, &peers, "admin_getPeers")
+	return
+}
+
+// getFileLocation Get file location
+func (c *AdminClient) GetFileLocation(ctx context.Context, txSeq uint64, allShards bool) (locations []LocationInfo, err error) {
+	err = c.provider.CallContext(ctx, &locations, "admin_getFileLocation", txSeq, allShards)
 	return
 }

--- a/node/types.go
+++ b/node/types.go
@@ -1,6 +1,7 @@
 package node
 
 import (
+	"github.com/0glabs/0g-storage-client/common/shard"
 	"github.com/0glabs/0g-storage-client/core/merkle"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -119,4 +120,10 @@ type PeerInfo struct {
 	IsTrusted           bool                 `json:"isTrusted"`
 	ConnectionDirection string               `json:"connectionDirection"` // Incoming/Outgoing/empty
 	Enr                 string               `json:"enr"`                 // maybe empty
+}
+
+// LocationInfo file location information
+type LocationInfo struct {
+	Ip          string            `json:"ip"`
+	ShardConfig shard.ShardConfig `json:"shardConfig"`
 }

--- a/transfer/uploader.go
+++ b/transfer/uploader.go
@@ -85,12 +85,12 @@ func (uploader *Uploader) checkLogExistance(ctx context.Context, root common.Has
 		if err != nil {
 			return false, errors.WithMessage(err, fmt.Sprintf("Failed to get file info from storage node %v", client.URL()))
 		}
-		// log entry unavailable yet
-		if info == nil {
-			return false, nil
+		// log entry available
+		if info != nil {
+			return true, nil
 		}
 	}
-	return true, nil
+	return false, nil
 }
 
 // BatchUpload submit multiple data to 0g storage contract batchly in single on-chain transaction, then transfer the data to the storage nodes.


### PR DESCRIPTION
- Add file location cache for indexer service, add relevant RPC;
- Add `--indexer` for download CLI;
- Change the default behavior of `--skipTx`, now it does not throw error when the file cannot find on-chain but send a transaction instead. Changed default `--skipTx` of uploading ordinary file to `true`.