### PR TITLE
feat: random node selection & interface level retry

### DIFF
--- a/cmd/kv_write.go
+++ b/cmd/kv_write.go
@@ -130,7 +130,7 @@ func kvWrite(*cobra.Command, []string) {
 		if err != nil {
 			logrus.WithError(err).Fatal("Failed to initialize indexer client")
 		}
-		if clients, err = indexerClient.SelectNodes(ctx, max(1, opt.ExpectedReplica)); err != nil {
+		if clients, err = indexerClient.SelectNodes(ctx, max(1, opt.ExpectedReplica), []string{}); err != nil {
 			logrus.WithError(err).Fatal("failed to select nodes from indexer")
 		}
 	}

--- a/common/shard/types.go
+++ b/common/shard/types.go
@@ -2,6 +2,7 @@ package shard
 
 import (
 	"sort"
+	"time"
 
 	"golang.org/x/exp/rand"
 )
@@ -79,8 +80,9 @@ func Select(nodes []*ShardedNode, expectedReplica uint, random bool) ([]*Sharded
 	}
 	if random {
 		// shuffle
+		rng := rand.New(rand.NewSource(uint64(time.Now().UnixNano())))
 		for i := range nodes {
-			j := rand.Intn(i + 1)
+			j := rng.Intn(i + 1)
 			nodes[i], nodes[j] = nodes[j], nodes[i]
 		}
 	} else {

--- a/common/shard/types_test.go
+++ b/common/shard/types_test.go
@@ -40,7 +40,7 @@ func TestSelect(t *testing.T) {
 		makeShardNode(16, 14),
 		makeShardNode(16, 15),
 	}
-	selected, found := Select(shardedNodes, 2)
+	selected, found := Select(shardedNodes, 2, false)
 	assert.Equal(t, found, true)
 	fmt.Println(selected)
 	assert.Equal(t, len(selected), 5)
@@ -49,7 +49,7 @@ func TestSelect(t *testing.T) {
 	assert.DeepEqual(t, selected[2], makeShardNode(4, 3))
 	assert.DeepEqual(t, selected[3], makeShardNode(8, 1))
 	assert.DeepEqual(t, selected[4], makeShardNode(8, 5))
-	selected, found = Select(shardedNodes, 3)
+	selected, found = Select(shardedNodes, 3, false)
 	assert.Equal(t, found, true)
 	assert.Equal(t, len(selected), 15)
 	assert.DeepEqual(t, selected[0], makeShardNode(1, 0))
@@ -67,6 +67,6 @@ func TestSelect(t *testing.T) {
 	assert.DeepEqual(t, selected[12], makeShardNode(16, 11))
 	assert.DeepEqual(t, selected[13], makeShardNode(16, 13))
 	assert.DeepEqual(t, selected[14], makeShardNode(16, 15))
-	_, found = Select(shardedNodes, 4)
+	_, found = Select(shardedNodes, 4, false)
 	assert.Equal(t, found, false)
 }

--- a/indexer/client.go
+++ b/indexer/client.go
@@ -148,7 +148,7 @@ func (c *Client) Upload(ctx context.Context, flow *contract.FlowContract, data c
 		var rpcError *node.RPCError
 		if errors.As(err, &rpcError) {
 			dropped = append(dropped, rpcError.URL)
-			c.logger.Infof("dropped problematic node %v and retry..", rpcError.URL)
+			c.logger.Infof("dropped problematic node and retry: %v", rpcError.Error())
 		} else {
 			return err
 		}
@@ -173,7 +173,7 @@ func (c *Client) BatchUpload(ctx context.Context, flow *contract.FlowContract, d
 		var rpcError *node.RPCError
 		if errors.As(err, &rpcError) {
 			dropped = append(dropped, rpcError.URL)
-			c.logger.Infof("dropped problematic node %v and retry..", rpcError.URL)
+			c.logger.Infof("dropped problematic node and retry: %v", rpcError.Error())
 		} else {
 			return hash, roots, err
 		}
@@ -191,6 +191,11 @@ func (c *Client) Download(ctx context.Context, root, filename string, withProof 
 		client, err := node.NewZgsClient(location.URL, c.option.ProviderOption)
 		if err != nil {
 			c.logger.Debugf("failed to initialize client of node %v, dropped.", location.URL)
+			continue
+		}
+		config, err := client.GetShardConfig(ctx)
+		if err != nil || !config.IsValid() {
+			c.logger.Debugf("failed to get shard config of node %v, dropped.", client.URL())
 			continue
 		}
 		clients = append(clients, client)

--- a/indexer/file_location_cache.go
+++ b/indexer/file_location_cache.go
@@ -59,7 +59,7 @@ func (c *FileLocationCache) close() {
 
 func (c *FileLocationCache) GetFileLocations(ctx context.Context, txSeq uint64) ([]*shard.ShardedNode, error) {
 	if nodes, ok := c.cache.Get(txSeq); ok {
-		if _, covered := shard.Select(nodes, 1); covered {
+		if _, covered := shard.Select(nodes, 1, false); covered {
 			return nodes, nil
 		}
 	}
@@ -85,7 +85,7 @@ func (c *FileLocationCache) GetFileLocations(ctx context.Context, txSeq uint64) 
 		selected[v.URL()] = struct{}{}
 	}
 	logrus.Debugf("find file #%v from trusted nodes, got %v nodes holding the file", txSeq, len(nodes))
-	if _, covered := shard.Select(nodes, 1); covered {
+	if _, covered := shard.Select(nodes, 1, false); covered {
 		return nodes, nil
 	}
 	// trusted nodes do not hold all shards of the file, try to find file
@@ -149,7 +149,7 @@ func (c *FileLocationCache) GetFileLocations(ctx context.Context, txSeq uint64) 
 				break
 			}
 		}
-		if _, covered := shard.Select(nodes, 1); covered {
+		if _, covered := shard.Select(nodes, 1, false); covered {
 			return nodes, nil
 		}
 		if val, ok := c.latestFindFile.Load(txSeq); ok {

--- a/indexer/node_manager.go
+++ b/indexer/node_manager.go
@@ -83,11 +83,13 @@ func (nm *NodeManager) Trusted() ([]*shard.ShardedNode, error) {
 		start := time.Now()
 		config, err := v.GetShardConfig(context.Background())
 		if err != nil {
-			return nil, errors.WithMessagef(err, "Failed to retrieve shard config from trusted storage node %v", v.URL())
+			logrus.Debugf("Failed to retrieve shard config from trusted storage node %v, error: %v", v.URL(), err)
+			continue
 		}
 
 		if !config.IsValid() {
-			return nil, errors.Errorf("Invalid shard config retrieved from trusted storage node %v", v.URL())
+			logrus.Debugf("Invalid shard config retrieved from trusted storage node %v: %v", v.URL(), config)
+			continue
 		}
 
 		nodes = append(nodes, &shard.ShardedNode{

--- a/node/client_admin.go
+++ b/node/client_admin.go
@@ -34,46 +34,46 @@ func NewAdminClient(url string, option ...providers.Option) (*AdminClient, error
 
 // FindFile Call find_file to update file location cache
 func (c *AdminClient) FindFile(ctx context.Context, txSeq uint64) (ret int, err error) {
-	err = c.provider.CallContext(ctx, &ret, "admin_findFile", txSeq)
+	err = c.wrapError(c.provider.CallContext(ctx, &ret, "admin_findFile", txSeq), "admin_findFile")
 	return
 }
 
 // Shutdown Call admin_shutdown to shutdown the node.
 func (c *AdminClient) Shutdown(ctx context.Context) (ret int, err error) {
-	err = c.provider.CallContext(ctx, &ret, "admin_shutdown")
+	err = c.wrapError(c.provider.CallContext(ctx, &ret, "admin_shutdown"), "admin_shutdown")
 	return
 }
 
 // StartSyncFile Call admin_startSyncFile to request synchronization of a file.
 func (c *AdminClient) StartSyncFile(ctx context.Context, txSeq uint64) (ret int, err error) {
-	err = c.provider.CallContext(ctx, &ret, "admin_startSyncFile", txSeq)
+	err = c.wrapError(c.provider.CallContext(ctx, &ret, "admin_startSyncFile", txSeq), "admin_startSyncFile")
 	return
 }
 
 // StartSyncChunks Call admin_startSyncChunks to request synchronization of specified chunks.
 func (c *AdminClient) StartSyncChunks(ctx context.Context, txSeq, startIndex, endIndex uint64) (ret int, err error) {
-	err = c.provider.CallContext(ctx, &ret, "admin_startSyncChunks", txSeq, startIndex, endIndex)
+	err = c.wrapError(c.provider.CallContext(ctx, &ret, "admin_startSyncChunks", txSeq, startIndex, endIndex), "admin_startSyncChunks")
 	return
 }
 
 // TerminateSync Call admin_terminateSync to terminate a file sync.
 func (c *AdminClient) TerminateSync(ctx context.Context, txSeq uint64) (terminated bool, err error) {
-	err = c.provider.CallContext(ctx, &terminated, "admin_terminateSync", txSeq)
+	err = c.wrapError(c.provider.CallContext(ctx, &terminated, "admin_terminateSync", txSeq), "admin_terminateSync")
 	return
 }
 
 // GetSyncStatus Call admin_getSyncStatus to retrieve the sync status of specified file.
 func (c *AdminClient) GetSyncStatus(ctx context.Context, txSeq uint64) (status string, err error) {
-	err = c.provider.CallContext(ctx, &status, "admin_getSyncStatus", txSeq)
+	err = c.wrapError(c.provider.CallContext(ctx, &status, "admin_getSyncStatus", txSeq), "admin_getSyncStatus")
 	return
 }
 
 // GetSyncInfo Call admin_getSyncInfo to retrieve the sync status of specified file or all files.
 func (c *AdminClient) GetSyncInfo(ctx context.Context, tx_seq ...uint64) (files map[uint64]FileSyncInfo, err error) {
 	if len(tx_seq) > 0 {
-		err = c.provider.CallContext(ctx, &files, "admin_getSyncInfo", tx_seq[0])
+		err = c.wrapError(c.provider.CallContext(ctx, &files, "admin_getSyncInfo", tx_seq[0]), "admin_getSyncInfo")
 	} else {
-		err = c.provider.CallContext(ctx, &files, "admin_getSyncInfo")
+		err = c.wrapError(c.provider.CallContext(ctx, &files, "admin_getSyncInfo"), "admin_getSyncInfo")
 	}
 
 	return
@@ -81,18 +81,18 @@ func (c *AdminClient) GetSyncInfo(ctx context.Context, tx_seq ...uint64) (files 
 
 // GetNetworkInfo Call admin_getNetworkInfo to retrieve the network information.
 func (c *AdminClient) GetNetworkInfo(ctx context.Context) (info NetworkInfo, err error) {
-	err = c.provider.CallContext(ctx, &info, "admin_getNetworkInfo")
+	err = c.wrapError(c.provider.CallContext(ctx, &info, "admin_getNetworkInfo"), "admin_getNetworkInfo")
 	return
 }
 
 // GetPeers Call admin_getPeers to retrieve all discovered network peers.
 func (c *AdminClient) GetPeers(ctx context.Context) (peers map[string]*PeerInfo, err error) {
-	err = c.provider.CallContext(ctx, &peers, "admin_getPeers")
+	err = c.wrapError(c.provider.CallContext(ctx, &peers, "admin_getPeers"), "admin_getPeers")
 	return
 }
 
 // getFileLocation Get file location
 func (c *AdminClient) GetFileLocation(ctx context.Context, txSeq uint64, allShards bool) (locations []LocationInfo, err error) {
-	err = c.provider.CallContext(ctx, &locations, "admin_getFileLocation", txSeq, allShards)
+	err = c.wrapError(c.provider.CallContext(ctx, &locations, "admin_getFileLocation", txSeq, allShards), "admin_getFileLocation")
 	return
 }

--- a/node/client_kv.go
+++ b/node/client_kv.go
@@ -39,7 +39,7 @@ func (c *KvClient) GetValue(ctx context.Context, streamId common.Hash, key []byt
 	if len(version) > 0 {
 		args = append(args, version[0])
 	}
-	err = c.provider.CallContext(ctx, &val, "kv_getValue", args...)
+	err = c.wrapError(c.provider.CallContext(ctx, &val, "kv_getValue", args...), "kv_getValue")
 	return
 }
 
@@ -49,7 +49,7 @@ func (c *KvClient) GetNext(ctx context.Context, streamId common.Hash, key []byte
 	if len(version) > 0 {
 		args = append(args, version[0])
 	}
-	err = c.provider.CallContext(ctx, &val, "kv_getNext", args...)
+	err = c.wrapError(c.provider.CallContext(ctx, &val, "kv_getNext", args...), "kv_getNext")
 	return
 }
 
@@ -59,7 +59,7 @@ func (c *KvClient) GetPrev(ctx context.Context, streamId common.Hash, key []byte
 	if len(version) > 0 {
 		args = append(args, version[0])
 	}
-	err = c.provider.CallContext(ctx, &val, "kv_getPrev", args...)
+	err = c.wrapError(c.provider.CallContext(ctx, &val, "kv_getPrev", args...), "kv_getPrev")
 	return
 }
 
@@ -69,7 +69,7 @@ func (c *KvClient) GetFirst(ctx context.Context, streamId common.Hash, startInde
 	if len(version) > 0 {
 		args = append(args, version[0])
 	}
-	err = c.provider.CallContext(ctx, &val, "kv_getFirst", args...)
+	err = c.wrapError(c.provider.CallContext(ctx, &val, "kv_getFirst", args...), "kv_getFirst")
 	return
 }
 
@@ -79,19 +79,19 @@ func (c *KvClient) GetLast(ctx context.Context, streamId common.Hash, startIndex
 	if len(version) > 0 {
 		args = append(args, version[0])
 	}
-	err = c.provider.CallContext(ctx, &val, "kv_getLast", args...)
+	err = c.wrapError(c.provider.CallContext(ctx, &val, "kv_getLast", args...), "kv_getLast")
 	return
 }
 
 // GetTransactionResult Call kv_getTransactionResult RPC to query the kv replay status of a given file.
 func (c *KvClient) GetTransactionResult(ctx context.Context, txSeq uint64) (result string, err error) {
-	err = c.provider.CallContext(ctx, &result, "kv_getTransactionResult", txSeq)
+	err = c.wrapError(c.provider.CallContext(ctx, &result, "kv_getTransactionResult", txSeq), "kv_getTransactionResult")
 	return
 }
 
 // GetHoldingStreamIds Call kv_getHoldingStreamIds RPC to query the stream ids monitered by the kv node.
 func (c *KvClient) GetHoldingStreamIds(ctx context.Context) (streamIds []common.Hash, err error) {
-	err = c.provider.CallContext(ctx, &streamIds, "kv_getHoldingStreamIds")
+	err = c.wrapError(c.provider.CallContext(ctx, &streamIds, "kv_getHoldingStreamIds"), "kv_getHoldingStreamIds")
 	return
 }
 
@@ -101,7 +101,7 @@ func (c *KvClient) HasWritePermission(ctx context.Context, account common.Addres
 	if len(version) > 0 {
 		args = append(args, version[0])
 	}
-	err = c.provider.CallContext(ctx, &hasPermission, "kv_hasWritePermission", args...)
+	err = c.wrapError(c.provider.CallContext(ctx, &hasPermission, "kv_hasWritePermission", args...), "kv_hasWritePermission")
 	return
 }
 
@@ -111,7 +111,7 @@ func (c *KvClient) IsAdmin(ctx context.Context, account common.Address, streamId
 	if len(version) > 0 {
 		args = append(args, version[0])
 	}
-	err = c.provider.CallContext(ctx, &isAdmin, "kv_isAdmin", args...)
+	err = c.wrapError(c.provider.CallContext(ctx, &isAdmin, "kv_isAdmin", args...), "kv_isAdmin")
 	return
 }
 
@@ -121,7 +121,7 @@ func (c *KvClient) IsSpecialKey(ctx context.Context, streamId common.Hash, key [
 	if len(version) > 0 {
 		args = append(args, version[0])
 	}
-	err = c.provider.CallContext(ctx, &isSpecialKey, "kv_isSpecialKey", args...)
+	err = c.wrapError(c.provider.CallContext(ctx, &isSpecialKey, "kv_isSpecialKey", args...), "kv_isSpecialKey")
 	return
 }
 
@@ -131,7 +131,7 @@ func (c *KvClient) IsWriterOfKey(ctx context.Context, account common.Address, st
 	if len(version) > 0 {
 		args = append(args, version[0])
 	}
-	err = c.provider.CallContext(ctx, &isWriter, "kv_isWriterOfKey", args...)
+	err = c.wrapError(c.provider.CallContext(ctx, &isWriter, "kv_isWriterOfKey", args...), "kv_isWriterOfKey")
 	return
 }
 
@@ -141,6 +141,6 @@ func (c *KvClient) IsWriterOfStream(ctx context.Context, account common.Address,
 	if len(version) > 0 {
 		args = append(args, version[0])
 	}
-	err = c.provider.CallContext(ctx, &isWriter, "kv_isWriterOfStream", args...)
+	err = c.wrapError(c.provider.CallContext(ctx, &isWriter, "kv_isWriterOfStream", args...), "kv_isWriterOfStream")
 	return
 }

--- a/node/client_zgs.go
+++ b/node/client_zgs.go
@@ -48,37 +48,37 @@ func MustNewZgsClients(urls []string, option ...providers.Option) []*ZgsClient {
 
 // GetStatus Call zgs_getStatus RPC to get sync status of the node.
 func (c *ZgsClient) GetStatus(ctx context.Context) (status Status, err error) {
-	err = c.provider.CallContext(ctx, &status, "zgs_getStatus")
+	err = c.wrapError(c.provider.CallContext(ctx, &status, "zgs_getStatus"), "zgs_getStatus")
 	return
 }
 
 // GetFileInfo Call zgs_getFileInfo RPC to get the information of a file by file data root from the node.
 func (c *ZgsClient) GetFileInfo(ctx context.Context, root common.Hash) (file *FileInfo, err error) {
-	err = c.provider.CallContext(ctx, &file, "zgs_getFileInfo", root)
+	err = c.wrapError(c.provider.CallContext(ctx, &file, "zgs_getFileInfo", root), "zgs_getFileInfo")
 	return
 }
 
 // GetFileInfoByTxSeq Call zgs_getFileInfoByTxSeq RPC to get the information of a file by file sequence id from the node.
 func (c *ZgsClient) GetFileInfoByTxSeq(ctx context.Context, txSeq uint64) (file *FileInfo, err error) {
-	err = c.provider.CallContext(ctx, &file, "zgs_getFileInfoByTxSeq", txSeq)
+	err = c.wrapError(c.provider.CallContext(ctx, &file, "zgs_getFileInfoByTxSeq", txSeq), "zgs_getFileInfoByTxSeq")
 	return
 }
 
 // UploadSegment Call zgs_uploadSegment RPC to upload a segment to the node.
 func (c *ZgsClient) UploadSegment(ctx context.Context, segment SegmentWithProof) (ret int, err error) {
-	err = c.provider.CallContext(ctx, &ret, "zgs_uploadSegment", segment)
+	err = c.wrapError(c.provider.CallContext(ctx, &ret, "zgs_uploadSegment", segment), "zgs_uploadSegment")
 	return
 }
 
 // UploadSegments Call zgs_uploadSegments RPC to upload a slice of segments to the node.
 func (c *ZgsClient) UploadSegments(ctx context.Context, segments []SegmentWithProof) (ret int, err error) {
-	err = c.provider.CallContext(ctx, &ret, "zgs_uploadSegments", segments)
+	err = c.wrapError(c.provider.CallContext(ctx, &ret, "zgs_uploadSegments", segments), "zgs_uploadSegments")
 	return
 }
 
 // DownloadSegment Call zgs_downloadSegment RPC to download a segment from the node.
 func (c *ZgsClient) DownloadSegment(ctx context.Context, root common.Hash, startIndex, endIndex uint64) (data []byte, err error) {
-	err = c.provider.CallContext(ctx, &data, "zgs_downloadSegment", root, startIndex, endIndex)
+	err = c.wrapError(c.provider.CallContext(ctx, &data, "zgs_downloadSegment", root, startIndex, endIndex), "zgs_downloadSegment")
 	if len(data) == 0 {
 		return nil, err
 	}
@@ -87,12 +87,12 @@ func (c *ZgsClient) DownloadSegment(ctx context.Context, root common.Hash, start
 
 // DownloadSegmentWithProof Call zgs_downloadSegmentWithProof RPC to download a segment along with its merkle proof from the node.
 func (c *ZgsClient) DownloadSegmentWithProof(ctx context.Context, root common.Hash, index uint64) (segment *SegmentWithProof, err error) {
-	err = c.provider.CallContext(ctx, &segment, "zgs_downloadSegmentWithProof", root, index)
+	err = c.wrapError(c.provider.CallContext(ctx, &segment, "zgs_downloadSegmentWithProof", root, index), "zgs_downloadSegmentWithProof")
 	return
 }
 
 // GetShardConfig Call zgs_getShardConfig RPC to get the current shard configuration of the node.
 func (c *ZgsClient) GetShardConfig(ctx context.Context) (shardConfig shard.ShardConfig, err error) {
-	err = c.provider.CallContext(ctx, &shardConfig, "zgs_getShardConfig")
+	err = c.wrapError(c.provider.CallContext(ctx, &shardConfig, "zgs_getShardConfig"), "zgs_getShardConfig")
 	return
 }

--- a/node/errors.go
+++ b/node/errors.go
@@ -1,0 +1,13 @@
+package node
+
+import "fmt"
+
+type RPCError struct {
+	Message string
+	Method  string
+	URL     string
+}
+
+func (e *RPCError) Error() string {
+	return fmt.Sprintf("Node: %s, Method: %s, Message: %s", e.URL, e.Method, e.Message)
+}

--- a/node/rpc_client.go
+++ b/node/rpc_client.go
@@ -29,6 +29,17 @@ func (c *rpcClient) URL() string {
 	return c.url
 }
 
+func (c *rpcClient) wrapError(e error, method string) error {
+	if e == nil {
+		return nil
+	}
+	return &RPCError{
+		Message: e.Error(),
+		Method:  method,
+		URL:     c.URL(),
+	}
+}
+
 // Close close the underlying RPC client.
 func (c *rpcClient) Close() {
 	c.provider.Close()

--- a/tests/batch_upload_test.py
+++ b/tests/batch_upload_test.py
@@ -1,4 +1,5 @@
 import os
+import time
 
 from test_framework.test_framework import TestFramework
 from config.node_config import GENESIS_PRIV_KEY

--- a/transfer/downloader.go
+++ b/transfer/downloader.go
@@ -66,7 +66,7 @@ func (downloader *Downloader) queryFile(ctx context.Context, root common.Hash) (
 	for _, v := range downloader.clients {
 		info, err = v.GetFileInfo(ctx, root)
 		if err != nil {
-			return nil, errors.WithMessagef(err, "Failed to get file info on node %v", v.URL())
+			return nil, err
 		}
 
 		if info == nil {

--- a/transfer/uploader.go
+++ b/transfer/uploader.go
@@ -6,6 +6,7 @@ import (
 	"math/big"
 	"runtime"
 	"sort"
+	"strings"
 	"time"
 
 	zg_common "github.com/0glabs/0g-storage-client/common"
@@ -33,7 +34,7 @@ var dataAlreadyExistsError = "Invalid params: root; data: already uploaded and f
 var segmentAlreadyExistsError = "segment has already been uploaded or is being uploaded"
 
 func isDuplicateError(msg string) bool {
-	return msg == dataAlreadyExistsError || msg == segmentAlreadyExistsError
+	return strings.Contains(msg, dataAlreadyExistsError) || strings.Contains(msg, segmentAlreadyExistsError)
 }
 
 // UploadOption upload option for a file
@@ -92,7 +93,7 @@ func (uploader *Uploader) checkLogExistance(ctx context.Context, root common.Has
 	for _, client := range uploader.clients {
 		info, err := client.GetFileInfo(ctx, root)
 		if err != nil {
-			return false, errors.WithMessage(err, fmt.Sprintf("Failed to get file info from storage node %v", client.URL()))
+			return false, err
 		}
 		// log entry available
 		if info != nil {
@@ -346,7 +347,7 @@ func (uploader *Uploader) waitForLogEntry(ctx context.Context, root common.Hash,
 		for _, client := range uploader.clients {
 			info, err := client.GetFileInfo(ctx, root)
 			if err != nil {
-				return errors.WithMessage(err, fmt.Sprintf("Failed to get file info from storage node %v", client.URL()))
+				return err
 			}
 			// log entry unavailable yet
 			if info == nil {

--- a/transfer/uploader_parallel.go
+++ b/transfer/uploader_parallel.go
@@ -7,7 +7,6 @@ import (
 	"github.com/0glabs/0g-storage-client/core"
 	"github.com/0glabs/0g-storage-client/core/merkle"
 	"github.com/0glabs/0g-storage-client/node"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -76,7 +75,7 @@ func (uploader *segmentUploader) ParallelDo(ctx context.Context, routine int, ta
 		segIndex += uploadTask.numShard
 	}
 	if _, err := uploader.clients[uploadTask.clientIndex].UploadSegments(ctx, segments); err != nil && !isDuplicateError(err.Error()) {
-		return nil, errors.WithMessage(err, "Failed to upload segment")
+		return nil, err
 	}
 
 	if uploader.logger.IsLevelEnabled(logrus.DebugLevel) {


### PR DESCRIPTION
- During the upload, select a set of nodes that meet the criteria randomly from the nodes returned by the indexer, instead of sorting by ShardConfig
- Add interface level retry for `Upload` and `BatchUpload` of indexer client

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/0glabs/0g-storage-client/45)
<!-- Reviewable:end -->
