### PR TITLE
feat: split large files

### DIFF
--- a/cmd/download.go
+++ b/cmd/download.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"runtime"
 	"time"
 
 	"github.com/0glabs/0g-storage-client/common"
@@ -22,6 +23,8 @@ type downloadArgument struct {
 	root  string
 	proof bool
 
+	routines int
+
 	timeout time.Duration
 }
 
@@ -36,6 +39,8 @@ func bindDownloadFlags(cmd *cobra.Command, args *downloadArgument) {
 	cmd.Flags().StringVar(&args.root, "root", "", "Merkle root to download file")
 	cmd.MarkFlagRequired("root")
 	cmd.Flags().BoolVar(&args.proof, "proof", false, "Whether to download with merkle proof for validation")
+
+	cmd.Flags().IntVar(&args.routines, "routines", runtime.GOMAXPROCS(0), "number of go routines for downloading simutanously")
 
 	cmd.Flags().DurationVar(&args.timeout, "timeout", 0, "cli task timeout, 0 for no timeout")
 }
@@ -100,6 +105,7 @@ func newDownloader(args downloadArgument) (transfer.IDownloader, func(), error) 
 		closer()
 		return nil, nil, err
 	}
+	downloader.WithRoutines(downloadArgs.routines)
 
 	return downloader, closer, nil
 }

--- a/cmd/upload.go
+++ b/cmd/upload.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"math/big"
+	"strings"
 	"time"
 
 	zg_common "github.com/0glabs/0g-storage-client/common"
@@ -52,6 +53,8 @@ type uploadArgument struct {
 	finalityRequired bool
 	taskSize         uint
 
+	fragmentSize int64
+
 	timeout time.Duration
 }
 
@@ -70,6 +73,8 @@ func bindUploadFlags(cmd *cobra.Command, args *uploadArgument) {
 	cmd.Flags().BoolVar(&args.skipTx, "skip-tx", true, "Skip sending the transaction on chain if already exists")
 	cmd.Flags().BoolVar(&args.finalityRequired, "finality-required", false, "Wait for file finality on nodes to upload")
 	cmd.Flags().UintVar(&args.taskSize, "task-size", 10, "Number of segments to upload in single rpc request")
+
+	cmd.Flags().Int64Var(&args.fragmentSize, "fragment-size", 1024*1024*1024*5, "the size of fragment to split into when file is too large")
 
 	cmd.Flags().DurationVar(&args.timeout, "timeout", 0, "cli task timeout, 0 for no timeout")
 }
@@ -137,8 +142,18 @@ func upload(*cobra.Command, []string) {
 	}
 	defer closer()
 
-	if _, err := uploader.Upload(ctx, file, opt); err != nil {
+	_, roots, err := uploader.SplitableUpload(ctx, file, uploadArgs.fragmentSize, opt)
+	if err != nil {
 		logrus.WithError(err).Fatal("Failed to upload file")
+	}
+	if len(roots) == 1 {
+		logrus.Infof("file uploaded, root = %v", roots[0])
+	} else {
+		s := make([]string, len(roots))
+		for i, root := range roots {
+			s[i] = root.String()
+		}
+		logrus.Infof("file uploaded in %v fragments, roots = %v", len(roots), strings.Join(s, ","))
 	}
 }
 

--- a/cmd/upload.go
+++ b/cmd/upload.go
@@ -76,7 +76,7 @@ func bindUploadFlags(cmd *cobra.Command, args *uploadArgument) {
 	cmd.Flags().BoolVar(&args.finalityRequired, "finality-required", false, "Wait for file finality on nodes to upload")
 	cmd.Flags().UintVar(&args.taskSize, "task-size", 10, "Number of segments to upload in single rpc request")
 
-	cmd.Flags().Int64Var(&args.fragmentSize, "fragment-size", 1024*1024*1024*5, "the size of fragment to split into when file is too large")
+	cmd.Flags().Int64Var(&args.fragmentSize, "fragment-size", 1024*1024*1024*4, "the size of fragment to split into when file is too large")
 
 	cmd.Flags().IntVar(&args.routines, "routines", runtime.GOMAXPROCS(0), "number of go routines for uploading simutanously")
 

--- a/cmd/upload_dir.go
+++ b/cmd/upload_dir.go
@@ -58,6 +58,7 @@ func uploadDir(*cobra.Command, []string) {
 		logrus.WithError(err).Fatal("Failed to initialize uploader")
 	}
 	defer closer()
+	uploader.WithRoutines(uploadArgs.routines)
 
 	txnHash, rootHash, err := uploader.UploadDir(ctx, uploadDirArgs.file, opt)
 	if err != nil {

--- a/common/shard/types.go
+++ b/common/shard/types.go
@@ -2,9 +2,8 @@ package shard
 
 import (
 	"sort"
-	"time"
 
-	"golang.org/x/exp/rand"
+	"github.com/0glabs/0g-storage-client/common/util"
 )
 
 type ShardConfig struct {
@@ -130,12 +129,7 @@ func CheckReplica(shardConfigs []*ShardConfig, expectedReplica uint) bool {
 // Helper function to pre-process (sort or shuffle) the nodes before selection
 func prepareSelectionNodes(nodes []*ShardedNode, random bool) []*ShardedNode {
 	if random {
-		// Shuffle the nodes randomly if needed
-		rng := rand.New(rand.NewSource(uint64(time.Now().UnixNano())))
-		for i := range nodes {
-			j := rng.Intn(i + 1)
-			nodes[i], nodes[j] = nodes[j], nodes[i]
-		}
+		util.Shuffle(nodes)
 	} else {
 		// Sort nodes based on NumShard and ShardId
 		sort.Slice(nodes, func(i, j int) bool {

--- a/common/util/shuffle.go
+++ b/common/util/shuffle.go
@@ -1,0 +1,15 @@
+package util
+
+import (
+	"time"
+
+	"golang.org/x/exp/rand"
+)
+
+func Shuffle[T any](items []T) {
+	rng := rand.New(rand.NewSource(uint64(time.Now().UnixNano())))
+	for i := range items {
+		j := rng.Intn(i + 1)
+		items[i], items[j] = items[j], items[i]
+	}
+}

--- a/core/dataflow.go
+++ b/core/dataflow.go
@@ -30,10 +30,11 @@ var (
 type IterableData interface {
 	NumChunks() uint64
 	NumSegments() uint64
+	Offset() int64
 	Size() int64
 	PaddedSize() uint64
-	Iterate(offset int64, batch int64, flowPadding bool) Iterator
 	Read(buf []byte, offset int64) (int, error)
+	Split(fragmentSize int64) []IterableData
 }
 
 // MerkleTree create merkle tree of the data.

--- a/core/flow.go
+++ b/core/flow.go
@@ -43,7 +43,7 @@ func (flow *Flow) CreateSubmission() (*contract.Submission, error) {
 	return &submission, nil
 }
 
-func nextPow2(input uint64) uint64 {
+func NextPow2(input uint64) uint64 {
 	x := input
 	x -= 1
 	x |= x >> 32
@@ -57,7 +57,7 @@ func nextPow2(input uint64) uint64 {
 }
 
 func ComputePaddedSize(chunks uint64) (uint64, uint64) {
-	chunksNextPow2 := nextPow2(chunks)
+	chunksNextPow2 := NextPow2(chunks)
 	if chunksNextPow2 == chunks {
 		return chunksNextPow2, chunksNextPow2
 	}

--- a/gateway/local_apis.go
+++ b/gateway/local_apis.go
@@ -131,7 +131,7 @@ func uploadLocalFile(c *gin.Context) (interface{}, error) {
 	}
 	defer file.Close()
 
-	if _, err := uploader.Upload(context.Background(), file); err != nil {
+	if _, _, err := uploader.Upload(context.Background(), file); err != nil {
 		return nil, err
 	}
 

--- a/indexer/client.go
+++ b/indexer/client.go
@@ -145,7 +145,7 @@ func (c *Client) Upload(ctx context.Context, w3Client *web3go.Client, data core.
 		if err != nil {
 			return eth_common.Hash{}, err
 		}
-		txHash, err := uploader.Upload(ctx, data, option...)
+		txHash, _, err := uploader.Upload(ctx, data, option...)
 		var rpcError *node.RPCError
 		if errors.As(err, &rpcError) {
 			dropped = append(dropped, rpcError.URL)
@@ -157,7 +157,7 @@ func (c *Client) Upload(ctx context.Context, w3Client *web3go.Client, data core.
 }
 
 // BatchUpload submit multiple data to 0g storage contract batchly in single on-chain transaction, then transfer the data to the storage nodes selected from indexer service.
-func (c *Client) BatchUpload(ctx context.Context, w3Client *web3go.Client, datas []core.IterableData, waitForLogEntry bool, option ...transfer.BatchUploadOption) (eth_common.Hash, []eth_common.Hash, error) {
+func (c *Client) BatchUpload(ctx context.Context, w3Client *web3go.Client, datas []core.IterableData, option ...transfer.BatchUploadOption) (eth_common.Hash, []eth_common.Hash, error) {
 	expectedReplica := uint(1)
 	if len(option) > 0 {
 		for _, opt := range option[0].DataOptions {
@@ -174,7 +174,7 @@ func (c *Client) BatchUpload(ctx context.Context, w3Client *web3go.Client, datas
 		if err != nil {
 			return eth_common.Hash{}, nil, err
 		}
-		hash, roots, err := uploader.BatchUpload(ctx, datas, waitForLogEntry, option...)
+		hash, roots, err := uploader.BatchUpload(ctx, datas, option...)
 		var rpcError *node.RPCError
 		if errors.As(err, &rpcError) {
 			dropped = append(dropped, rpcError.URL)

--- a/kv/batcher.go
+++ b/kv/batcher.go
@@ -61,7 +61,7 @@ func (b *Batcher) Exec(ctx context.Context, option ...transfer.UploadOption) (co
 		opt = option[0]
 	}
 	opt.Tags = b.buildTags()
-	txHash, err := uploader.Upload(ctx, data, opt)
+	txHash, _, err := uploader.Upload(ctx, data, opt)
 	if err != nil {
 		return txHash, errors.WithMessagef(err, "Failed to upload data")
 	}

--- a/tests/cli_skip_tx_test.py
+++ b/tests/cli_skip_tx_test.py
@@ -54,7 +54,7 @@ class SkipTxTest(ClientTestFramework):
             self.nodes[node_idx].rpc_url,
             None,
             file_to_upload,
-            True
+            skip_tx=True
         )
         wait_until(lambda: self.contract.num_submissions() == 1)
         assert_equal(w3.eth.get_transaction_count(GENESIS_ACCOUNT.address), nonce)

--- a/tests/go_tests/batch_upload_test/main.go
+++ b/tests/go_tests/batch_upload_test/main.go
@@ -46,7 +46,7 @@ func runTest() error {
 	if err != nil {
 		return errors.WithMessage(err, "failed to initialize indexer client")
 	}
-	_, roots, err := indexerClient.BatchUpload(ctx, w3client, datas, true, transfer.BatchUploadOption{
+	_, roots, err := indexerClient.BatchUpload(ctx, w3client, datas, transfer.BatchUploadOption{
 		TaskSize:    5,
 		DataOptions: opts,
 	})

--- a/tests/go_tests/indexer_test/main.go
+++ b/tests/go_tests/indexer_test/main.go
@@ -75,7 +75,7 @@ func runTest() error {
 		return errors.WithMessage(err, "failed to initialize uploader")
 	}
 
-	if _, err := uploader.Upload(context.Background(), data, transfer.UploadOption{
+	if _, _, err := uploader.Upload(context.Background(), data, transfer.UploadOption{
 		FinalityRequired: transfer.FileFinalized,
 	}); err != nil {
 		return errors.WithMessage(err, "failed to upload file")

--- a/tests/splitable_upload_test.py
+++ b/tests/splitable_upload_test.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+
+import random
+import tempfile
+import os
+
+from config.node_config import GENESIS_ACCOUNT
+from utility.utils import (
+    wait_until,
+)
+from client_test_framework.test_framework import ClientTestFramework
+
+def files_are_equal(file1, file2):
+    if os.path.getsize(file1) != os.path.getsize(file2):
+        return False
+
+    with open(file1, 'rb') as f1, open(file2, 'rb') as f2:
+        while True:
+            chunk1 = f1.read(4096)
+            chunk2 = f2.read(4096)
+            
+            if chunk1 != chunk2:
+                return False
+            
+            if not chunk1:  
+                break
+
+    return True 
+
+
+class FileUploadDownloadTest(ClientTestFramework):
+    def setup_params(self):
+        self.num_blockchain_nodes = 1
+        self.num_nodes = 4
+        self.zgs_node_configs[0] = {
+            "db_max_num_sectors": 2 ** 30,
+            "shard_position": "0/4"
+        }
+        self.zgs_node_configs[1] = {
+            "db_max_num_sectors": 2 ** 30,
+            "shard_position": "1/4"
+        }
+        self.zgs_node_configs[2] = {
+            "db_max_num_sectors": 2 ** 30,
+            "shard_position": "2/4"
+        }
+        self.zgs_node_configs[3] = {
+            "db_max_num_sectors": 2 ** 30,
+            "shard_position": "3/4"
+        }
+
+    def run_test(self):
+        size = 50 * 1024 * 1024 # 50M
+        file_to_upload = tempfile.NamedTemporaryFile(dir=self.root_dir, delete=False)
+        data = random.randbytes(size)
+
+        file_to_upload.write(data)
+        file_to_upload.close()
+
+        roots = self._upload_file_use_cli(
+            self.blockchain_nodes[0].rpc_url,
+            GENESIS_ACCOUNT.key,
+            ','.join([x.rpc_url for x in self.nodes]),
+            None,
+            file_to_upload,
+            fragment_size=1024*1024*3, # 3M, will aligned to 4M
+        )
+
+        self.log.info("roots: %s", roots)
+        wait_until(lambda: self.contract.num_submissions() == 13)
+        
+        file_to_download = os.path.join(self.root_dir, "downloaded")
+        self._download_file_use_cli(','.join([x.rpc_url for x in self.nodes]), None, roots=roots, with_proof=True, file_to_download=file_to_download, remove=False)
+        assert(files_are_equal(file_to_upload.name, file_to_download))
+
+if __name__ == "__main__":
+    FileUploadDownloadTest().main()

--- a/transfer/downloader.go
+++ b/transfer/downloader.go
@@ -3,6 +3,7 @@ package transfer
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"runtime"
 
@@ -23,6 +24,7 @@ var (
 
 type IDownloader interface {
 	Download(ctx context.Context, root, filename string, withProof bool) error
+	DownloadFragments(ctx context.Context, roots []string, filename string, withProof bool) error
 }
 
 // Downloader downloader to download file to storage nodes
@@ -50,6 +52,38 @@ func NewDownloader(clients []*node.ZgsClient, opts ...zg_common.LogOption) (*Dow
 func (downloader *Downloader) WithRoutines(routines int) *Downloader {
 	downloader.routines = routines
 	return downloader
+}
+
+func (downloader *Downloader) DownloadFragments(ctx context.Context, roots []string, filename string, withProof bool) error {
+	outFile, err := os.Create(filename)
+	if err != nil {
+		return errors.WithMessage(err, "failed to create output file")
+	}
+	defer outFile.Close()
+
+	for _, root := range roots {
+		tempFile := fmt.Sprintf("%v.temp", root)
+		err := downloader.Download(ctx, root, tempFile, withProof)
+		if err != nil {
+			return errors.WithMessage(err, "Failed to download file")
+		}
+		inFile, err := os.Open(tempFile)
+		if err != nil {
+			return errors.WithMessage(err, fmt.Sprintf("failed to open file %s", tempFile))
+		}
+		_, err = io.Copy(outFile, inFile)
+		inFile.Close()
+		if err != nil {
+			return errors.WithMessage(err, fmt.Sprintf("failed to copy content from temp file %s", tempFile))
+		}
+
+		err = os.Remove(tempFile)
+		if err != nil {
+			return errors.WithMessage(err, fmt.Sprintf("failed to delete temp file %s:", tempFile))
+		}
+	}
+
+	return nil
 }
 
 // Download download data from storage nodes.

--- a/transfer/uploader.go
+++ b/transfer/uploader.go
@@ -170,6 +170,7 @@ func (uploader *Uploader) SplitableUpload(ctx context.Context, data core.Iterabl
 	}
 	// align size of fragment to 2 power
 	fragmentSize = int64(core.NextPow2(uint64(fragmentSize)))
+	uploader.logger.Infof("fragment size: %v", fragmentSize)
 
 	txHashes := make([]common.Hash, 0)
 	rootHashes := make([]common.Hash, 0)

--- a/transfer/uploader.go
+++ b/transfer/uploader.go
@@ -30,6 +30,7 @@ import (
 
 // defaultTaskSize is the default number of data segments to upload in a single upload RPC request
 const defaultTaskSize = uint(10)
+const defaultBatchSize = uint(10)
 
 var dataAlreadyExistsError = "Invalid params: root; data: already uploaded and finalized"
 var segmentAlreadyExistsError = "segment has already been uploaded or is being uploaded"
@@ -156,9 +157,55 @@ func checkLogExistance(ctx context.Context, clients []*node.ZgsClient, root comm
 	return info, nil
 }
 
+// SplitableUpload submit data to 0g storage contract and large data will be splited to reduce padding cost.
+func (uploader *Uploader) SplitableUpload(ctx context.Context, data core.IterableData, fragmentSize int64, option ...UploadOption) ([]common.Hash, []common.Hash, error) {
+	if fragmentSize < core.DefaultChunkSize {
+		fragmentSize = core.DefaultChunkSize
+	}
+	// align size of fragment to 2 power
+	fragmentSize = int64(core.NextPow2(uint64(fragmentSize)))
+
+	txHashes := make([]common.Hash, 0)
+	rootHashes := make([]common.Hash, 0)
+	if data.Size() <= fragmentSize {
+		txHash, rootHash, err := uploader.Upload(ctx, data, option...)
+		if err != nil {
+			return txHashes, rootHashes, err
+		}
+		txHashes = append(txHashes, txHash)
+		rootHashes = append(rootHashes, rootHash)
+	} else {
+		fragments := data.Split(fragmentSize)
+		uploader.logger.Infof("splitted origin file into %v fragments, %v bytes each.", len(fragments), fragmentSize)
+		var opt UploadOption
+		if len(option) > 0 {
+			opt = option[0]
+		}
+		for l := 0; l < len(fragments); l += int(defaultBatchSize) {
+			r := min(l+int(defaultBatchSize), len(fragments))
+			uploader.logger.Infof("batch submitting fragments %v to %v...", l, r)
+			opts := BatchUploadOption{
+				Fee:         nil,
+				Nonce:       nil,
+				DataOptions: make([]UploadOption, 0),
+			}
+			for i := l; i < r; i += 1 {
+				opts.DataOptions = append(opts.DataOptions, opt)
+			}
+			txHash, roots, err := uploader.BatchUpload(ctx, fragments[l:r], opts)
+			if err != nil {
+				return txHashes, rootHashes, err
+			}
+			txHashes = append(txHashes, txHash)
+			rootHashes = append(rootHashes, roots...)
+		}
+	}
+	return txHashes, rootHashes, nil
+}
+
 // BatchUpload submit multiple data to 0g storage contract batchly in single on-chain transaction, then transfer the data to the storage nodes.
 // The nonce for upload transaction will be the first non-nil nonce in given upload options, the protocol fee is the sum of fees in upload options.
-func (uploader *Uploader) BatchUpload(ctx context.Context, datas []core.IterableData, waitForLogEntry bool, option ...BatchUploadOption) (common.Hash, []common.Hash, error) {
+func (uploader *Uploader) BatchUpload(ctx context.Context, datas []core.IterableData, option ...BatchUploadOption) (common.Hash, []common.Hash, error) {
 	stageTimer := time.Now()
 
 	n := len(datas)
@@ -248,7 +295,7 @@ func (uploader *Uploader) BatchUpload(ctx context.Context, datas []core.Iterable
 	var receipt *types.Receipt
 	if len(toSubmitDatas) > 0 {
 		var err error
-		if txHash, receipt, err = uploader.SubmitLogEntry(ctx, toSubmitDatas, toSubmitTags, waitForLogEntry, opts.Nonce, opts.Fee); err != nil {
+		if txHash, receipt, err = uploader.SubmitLogEntry(ctx, toSubmitDatas, toSubmitTags, opts.Nonce, opts.Fee); err != nil {
 			return txHash, nil, errors.WithMessage(err, "Failed to submit log entry")
 		}
 		// Wait for storage node to retrieve log entry from blockchain
@@ -302,7 +349,7 @@ func (uploader *Uploader) BatchUpload(ctx context.Context, datas []core.Iterable
 
 // Upload submit data to 0g storage contract, then transfer the data to the storage nodes.
 // returns the submission transaction hash and the hash will be zero if transaction is skipped.
-func (uploader *Uploader) Upload(ctx context.Context, data core.IterableData, option ...UploadOption) (common.Hash, error) {
+func (uploader *Uploader) Upload(ctx context.Context, data core.IterableData, option ...UploadOption) (common.Hash, common.Hash, error) {
 	stageTimer := time.Now()
 
 	var opt UploadOption
@@ -319,44 +366,44 @@ func (uploader *Uploader) Upload(ctx context.Context, data core.IterableData, op
 	// Calculate file merkle root.
 	tree, err := core.MerkleTree(data)
 	if err != nil {
-		return common.Hash{}, errors.WithMessage(err, "Failed to create data merkle tree")
+		return common.Hash{}, common.Hash{}, errors.WithMessage(err, "Failed to create data merkle tree")
 	}
 	uploader.logger.WithField("root", tree.Root()).Info("Data merkle root calculated")
 
 	// Check existance
 	info, err := checkLogExistance(ctx, uploader.clients, tree.Root())
 	if err != nil {
-		return common.Hash{}, errors.WithMessage(err, "Failed to check if skipped log entry available on storage node")
+		return common.Hash{}, tree.Root(), errors.WithMessage(err, "Failed to check if skipped log entry available on storage node")
 	}
 	txHash := common.Hash{}
 	// Append log on blockchain
 	if !opt.SkipTx || info == nil {
 		var receipt *types.Receipt
 
-		txHash, receipt, err = uploader.SubmitLogEntry(ctx, []core.IterableData{data}, [][]byte{opt.Tags}, opt.FinalityRequired <= TransactionPacked, opt.Nonce, opt.Fee)
+		txHash, receipt, err = uploader.SubmitLogEntry(ctx, []core.IterableData{data}, [][]byte{opt.Tags}, opt.Nonce, opt.Fee)
 		if err != nil {
-			return txHash, errors.WithMessage(err, "Failed to submit log entry")
+			return txHash, tree.Root(), errors.WithMessage(err, "Failed to submit log entry")
 		}
 
 		// Wait for storage node to retrieve log entry from blockchain
 		info, err = uploader.waitForLogEntry(ctx, tree.Root(), TransactionPacked, receipt)
 		if err != nil {
-			return txHash, errors.WithMessage(err, "Failed to check if log entry available on storage node")
+			return txHash, tree.Root(), errors.WithMessage(err, "Failed to check if log entry available on storage node")
 		}
 	}
 	// Upload file to storage node
 	if err := uploader.uploadFile(ctx, info, data, tree, opt.ExpectedReplica, opt.TaskSize); err != nil {
-		return txHash, errors.WithMessage(err, "Failed to upload file")
+		return txHash, tree.Root(), errors.WithMessage(err, "Failed to upload file")
 	}
 
 	// Wait for transaction finality
 	if _, err = uploader.waitForLogEntry(ctx, tree.Root(), opt.FinalityRequired, nil); err != nil {
-		return txHash, errors.WithMessage(err, "Failed to wait for transaction finality on storage node")
+		return txHash, tree.Root(), errors.WithMessage(err, "Failed to wait for transaction finality on storage node")
 	}
 
 	uploader.logger.WithField("duration", time.Since(stageTimer)).Info("upload took")
 
-	return txHash, nil
+	return txHash, tree.Root(), nil
 }
 
 func (uploader *Uploader) UploadDir(ctx context.Context, folder string, option ...UploadOption) (txnHash, rootHash common.Hash, _ error) {
@@ -394,7 +441,7 @@ func (uploader *Uploader) UploadDir(ctx context.Context, folder string, option .
 	// Upload each file to the storage network.
 	for i := range relPaths {
 		path := filepath.Join(folder, relPaths[i])
-		txhash, err := uploader.UploadFile(ctx, path, option...)
+		txhash, _, err := uploader.UploadFile(ctx, path, option...)
 		if err != nil {
 			return txnHash, rootHash, errors.WithMessagef(err, "failed to upload file %s", path)
 		}
@@ -406,7 +453,7 @@ func (uploader *Uploader) UploadDir(ctx context.Context, folder string, option .
 	}
 
 	// Finally, upload the directory metadata
-	txnHash, err = uploader.Upload(ctx, iterdata, option...)
+	txnHash, _, err = uploader.Upload(ctx, iterdata, option...)
 	if err != nil {
 		err = errors.WithMessage(err, "failed to upload directory metadata")
 	}
@@ -414,7 +461,7 @@ func (uploader *Uploader) UploadDir(ctx context.Context, folder string, option .
 	return txnHash, rootHash, err
 }
 
-func (uploader *Uploader) UploadFile(ctx context.Context, path string, option ...UploadOption) (txnHash common.Hash, err error) {
+func (uploader *Uploader) UploadFile(ctx context.Context, path string, option ...UploadOption) (txnHash common.Hash, rootHash common.Hash, err error) {
 	file, err := core.Open(path)
 	if err != nil {
 		err = errors.WithMessagef(err, "failed to open file %s", path)
@@ -426,7 +473,7 @@ func (uploader *Uploader) UploadFile(ctx context.Context, path string, option ..
 }
 
 // SubmitLogEntry submit the data to 0g storage contract by sending a transaction
-func (uploader *Uploader) SubmitLogEntry(ctx context.Context, datas []core.IterableData, tags [][]byte, waitForReceipt bool, nonce *big.Int, fee *big.Int) (common.Hash, *types.Receipt, error) {
+func (uploader *Uploader) SubmitLogEntry(ctx context.Context, datas []core.IterableData, tags [][]byte, nonce *big.Int, fee *big.Int) (common.Hash, *types.Receipt, error) {
 	// Construct submission
 	submissions := make([]contract.Submission, len(datas))
 	for i := 0; i < len(datas); i++ {
@@ -498,12 +545,9 @@ func (uploader *Uploader) SubmitLogEntry(ctx context.Context, datas []core.Itera
 
 	uploader.logger.WithField("hash", tx.Hash().Hex()).Info("Succeeded to send transaction to append log entry")
 
-	if waitForReceipt {
-		// Wait for successful execution
-		receipt, err := uploader.flow.WaitForReceipt(ctx, tx.Hash(), true)
-		return tx.Hash(), receipt, err
-	}
-	return tx.Hash(), nil, nil
+	// Wait for successful execution
+	receipt, err := uploader.flow.WaitForReceipt(ctx, tx.Hash(), true)
+	return tx.Hash(), receipt, err
 }
 
 // Wait for log entry ready on storage node.


### PR DESCRIPTION
- Split large files into smaller fragments to avoid costly padding
- Add cli arguments to control number of go routines used for uploading/downloading

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/0glabs/0g-storage-client/67)
<!-- Reviewable:end -->
