### PR TITLE
feat: batch small files in upload-dir to reduce on-chain transactions

### DIFF
--- a/cli.md
+++ b/cli.md
@@ -242,6 +242,13 @@ Upload an entire directory using explicit storage nodes:
   --file <directory_path>
 ```
 
+Files in the directory are batched together to minimise on-chain transactions. The `--batch-size` flag controls this batching and applies in two ways:
+
+- **Small files** (size ≤ `--fragment-size`): up to `--batch-size` files are submitted in a single transaction. A directory with 100 files and `--batch-size=10` (the default) produces 10 file transactions instead of 100.
+- **Large files** (size > `--fragment-size`): the file is split into fragments first, and up to `--batch-size` fragments are submitted per transaction. Large files are always handled individually and do not share a transaction with other files.
+
+After all files are uploaded, a small metadata blob encoding the directory tree (file names, relative paths, and root hashes) is uploaded as a final transaction. The root hash returned by `upload-dir` is the hash of this metadata blob — it is the only value you need to retain in order to download the directory later.
+
 ### Encrypted Directory Upload
 
 Encrypt all files in a directory before uploading:
@@ -255,7 +262,7 @@ Encrypt all files in a directory before uploading:
   --encryption-key <0x_hex_encoded_32_byte_key>
 ```
 
-Each file (and the directory metadata) is encrypted individually using AES-256-CTR. The same encryption key is used to decrypt during download.
+Each file is encrypted with AES-256-CTR before uploading. Encryption is applied before the large/small split decision, so the encrypted size (original size + 17-byte header) determines whether a file is batched with others or split into fragments. The directory metadata blob is also encrypted. Use the same key with `download-dir --encryption-key` to decrypt.
 
 ### Directory Download
 

--- a/cmd/upload.go
+++ b/cmd/upload.go
@@ -90,7 +90,7 @@ func bindUploadFlags(cmd *cobra.Command, args *uploadArgument) {
 	cmd.Flags().BoolVar(&args.fastMode, "fast-mode", true, "Enable fast mode (no receipt wait, root-based upload for small files)")
 
 	cmd.Flags().Int64Var(&args.fragmentSize, "fragment-size", 1024*1024*1024*4, "the size of fragment to split into when file is too large")
-	cmd.Flags().UintVar(&args.batchSize, "batch-size", 10, "number of fragments to submit in a single batch")
+	cmd.Flags().UintVar(&args.batchSize, "batch-size", 10, "number of items to submit in a single on-chain transaction: fragments of a large split file (upload), or files in a directory (upload-dir)")
 
 	cmd.Flags().IntVar(&args.routines, "routines", runtime.GOMAXPROCS(0), "number of go routines for uploading simutanously")
 	cmd.Flags().UintVar(&args.maxGasPrice, "max-gas-price", 0, "max gas price to send transaction")

--- a/tests/cli_dir_test.py
+++ b/tests/cli_dir_test.py
@@ -131,8 +131,9 @@ class DirectoryUploadDownloadTest(ClientTestFramework):
 
         self.log.info("Root hash: %s", root_hash)
 
-        # 2 small files batched into 1 tx + 1 metadata = 2 submissions
-        wait_until(lambda: self.contract.num_submissions() == submission_count + 2)
+        # 2 files (1 submission each) + 1 metadata = 3 submissions.
+        # Batching reduces on-chain transactions but each file still creates one log entry.
+        wait_until(lambda: self.contract.num_submissions() == submission_count + 3)
 
         for node_idx in range(4):
             client = self.nodes[node_idx]
@@ -189,10 +190,9 @@ class DirectoryUploadDownloadTest(ClientTestFramework):
 
         self.log.info("Root hash: %s", root_hash)
 
-        # 5 small files batched into 1 tx + 1 metadata = 2 submissions
-        # (all files are well under the default 4GB fragment size even after +17B encryption header)
+        # 5 files (1 submission each) + 1 directory metadata = 6 submissions
         wait_until(
-            lambda: self.contract.num_submissions() == submission_count + 2,
+            lambda: self.contract.num_submissions() == submission_count + 6,
             timeout=120,
         )
 
@@ -224,17 +224,17 @@ class DirectoryUploadDownloadTest(ClientTestFramework):
 
         temp_dir = tempfile.TemporaryDirectory(dir=self.root_dir)
 
-        # large_file.bin: 768KB → 3 fragments, goes through uploadFragments (1 tx)
+        # large_file.bin: 768KB → 3 fragments → 3 submissions
         large_file_path = os.path.join(temp_dir.name, "large_file.bin")
         with open(large_file_path, "wb") as f:
             f.write(os.urandom(fragment_size * 3))
 
-        # small_file.bin: 1KB → fits in one fragment, accumulated into small-file batch
+        # small_file.bin: 1KB → 1 submission (batched with others in one tx)
         small_file_path = os.path.join(temp_dir.name, "small_file.bin")
         with open(small_file_path, "wb") as f:
             f.write(os.urandom(1024))
 
-        # subdir/split_file.bin: 512KB → 2 fragments, goes through uploadFragments (1 tx)
+        # subdir/split_file.bin: 512KB → 2 fragments → 2 submissions
         subdir_path = os.path.join(temp_dir.name, "subdir")
         os.makedirs(subdir_path)
         with open(os.path.join(subdir_path, "split_file.bin"), "wb") as f:
@@ -259,14 +259,10 @@ class DirectoryUploadDownloadTest(ClientTestFramework):
 
         self.log.info("Root hash: %s", root_hash)
 
-        # Processing order (alphabetical): large_file → small_file → subdir/split_file
-        #   large_file.bin:      flush empty pending (0 tx) + uploadFragments 3 frags = 1 tx
-        #   small_file.bin:      accumulated into pending batch
-        #   subdir/split_file:   flush pending (1 file) = 1 tx + uploadFragments 2 frags = 1 tx
-        #   metadata:            1 tx
-        # Total: 4 submissions
+        # 3 fragments (large_file) + 1 (small_file) + 2 fragments (split_file) + 1 metadata = 7
+        # Note: batching reduces transactions but not submissions (log entries).
         wait_until(
-            lambda: self.contract.num_submissions() == submission_count + 4,
+            lambda: self.contract.num_submissions() == submission_count + 7,
             timeout=120,
         )
 
@@ -297,17 +293,17 @@ class DirectoryUploadDownloadTest(ClientTestFramework):
 
         temp_dir = tempfile.TemporaryDirectory(dir=self.root_dir)
 
-        # large_enc.bin: 512KB + 17B header = 524305B → 3 fragments (1 tx)
+        # large_enc.bin: 512KB + 17B header = 524305B → 3 fragments → 3 submissions
         large_file_path = os.path.join(temp_dir.name, "large_enc.bin")
         with open(large_file_path, "wb") as f:
             f.write(os.urandom(fragment_size * 2))
 
-        # small_enc.bin: 2KB + 17B = 2065B → small, accumulated into pending batch
+        # small_enc.bin: 2KB + 17B = 2065B → 1 submission (batched in one tx)
         small_file_path = os.path.join(temp_dir.name, "small_enc.bin")
         with open(small_file_path, "wb") as f:
             f.write(os.urandom(2048))
 
-        # subdir/nested_enc.bin: 768KB + 17B = 786449B → 4 fragments (1 tx)
+        # subdir/nested_enc.bin: 768KB + 17B = 786449B → 4 fragments → 4 submissions
         subdir_path = os.path.join(temp_dir.name, "subdir")
         os.makedirs(subdir_path)
         with open(os.path.join(subdir_path, "nested_enc.bin"), "wb") as f:
@@ -331,14 +327,14 @@ class DirectoryUploadDownloadTest(ClientTestFramework):
 
         self.log.info("Root hash: %s", root_hash)
 
-        # Processing order (alphabetical): large_enc → small_enc → subdir/nested_enc
-        #   large_enc.bin:       flush empty pending (0 tx) + uploadFragments 3 frags = 1 tx
-        #   small_enc.bin:       accumulated into pending batch
-        #   subdir/nested_enc:   flush pending (1 file) = 1 tx + uploadFragments 4 frags = 1 tx
-        #   metadata:            1 tx
-        # Total: 4 submissions
+        # Encryption adds 17-byte header, which may push fragment count up by 1
+        # large_enc: ~512KB + 17B encrypted → 3 fragments (crosses 2-segment boundary)
+        # small_enc: ~2KB + 17B → 1 fragment
+        # nested_enc: ~768KB + 17B encrypted → 4 fragments (crosses 3-segment boundary)
+        # metadata: 1 fragment
+        # Total: 3 + 1 + 4 + 1 = 9
         wait_until(
-            lambda: self.contract.num_submissions() == submission_count + 4,
+            lambda: self.contract.num_submissions() >= submission_count + 9,
             timeout=120,
         )
 
@@ -364,10 +360,11 @@ class DirectoryUploadDownloadTest(ClientTestFramework):
         self.log.info("Encrypted+fragmented directory upload/download test passed")
 
     def __test_batched_directory(self):
-        """Test that small files are batched together — N files with batch_size=B
-        produces ceil(N/B) + 1 (metadata) transactions instead of N + 1."""
+        """Test that small files are grouped into fewer on-chain transactions via --batch-size.
+        Submission count is unchanged (each file is still one log entry); what changes is
+        the number of transactions: ceil(N/batch_size) instead of N."""
         batch_size = 2
-        num_files = 6  # ceil(6/2) = 3 batch txs + 1 metadata = 4 total
+        num_files = 6
 
         temp_dir = tempfile.TemporaryDirectory(dir=self.root_dir)
 
@@ -396,10 +393,11 @@ class DirectoryUploadDownloadTest(ClientTestFramework):
 
         self.log.info("Root hash: %s", root_hash)
 
-        # ceil(6/2) = 3 batch txs + 1 metadata = 4 submissions
-        expected = (num_files + batch_size - 1) // batch_size + 1
+        # 6 files (1 submission each) + 1 metadata = 7 submissions.
+        # With batch_size=2 this is ceil(6/2)=3 transactions instead of 6,
+        # but the submission (log entry) count is the same.
         wait_until(
-            lambda: self.contract.num_submissions() == submission_count + expected,
+            lambda: self.contract.num_submissions() == submission_count + num_files + 1,
             timeout=120,
         )
 

--- a/tests/cli_dir_test.py
+++ b/tests/cli_dir_test.py
@@ -86,6 +86,7 @@ class DirectoryUploadDownloadTest(ClientTestFramework):
         self.__test_encrypted_directory()
         self.__test_fragmented_directory()
         self.__test_encrypted_fragmented_directory()
+        self.__test_batched_directory()
 
     def __test_unencrypted_directory(self):
         temp_dir = tempfile.TemporaryDirectory(dir=self.root_dir)
@@ -118,6 +119,8 @@ class DirectoryUploadDownloadTest(ClientTestFramework):
             1,
         )
 
+        submission_count = self.contract.num_submissions()
+
         root_hash = self._upload_directory_use_cli(
             self.blockchain_nodes[0].rpc_url,
             GENESIS_ACCOUNT.key,
@@ -127,7 +130,9 @@ class DirectoryUploadDownloadTest(ClientTestFramework):
         )
 
         self.log.info("Root hash: %s", root_hash)
-        wait_until(lambda: self.contract.num_submissions() == 3)
+
+        # 2 small files batched into 1 tx + 1 metadata = 2 submissions
+        wait_until(lambda: self.contract.num_submissions() == submission_count + 2)
 
         for node_idx in range(4):
             client = self.nodes[node_idx]
@@ -184,9 +189,10 @@ class DirectoryUploadDownloadTest(ClientTestFramework):
 
         self.log.info("Root hash: %s", root_hash)
 
-        # 5 files + 1 directory metadata = 6 submissions
+        # 5 small files batched into 1 tx + 1 metadata = 2 submissions
+        # (all files are well under the default 4GB fragment size even after +17B encryption header)
         wait_until(
-            lambda: self.contract.num_submissions() == submission_count + 6,
+            lambda: self.contract.num_submissions() == submission_count + 2,
             timeout=120,
         )
 
@@ -214,25 +220,25 @@ class DirectoryUploadDownloadTest(ClientTestFramework):
 
     def __test_fragmented_directory(self):
         """Test directory upload with small fragment size to force file splitting."""
-        fragment_size = 262144  # 256KB — one segment, forces splitting for larger files
+        fragment_size = 262144  # 256KB — forces splitting for larger files
 
         temp_dir = tempfile.TemporaryDirectory(dir=self.root_dir)
 
-        # Create a file larger than fragment size so it gets split into multiple roots
+        # large_file.bin: 768KB → 3 fragments, goes through uploadFragments (1 tx)
         large_file_path = os.path.join(temp_dir.name, "large_file.bin")
         with open(large_file_path, "wb") as f:
-            f.write(os.urandom(fragment_size * 3))  # 768KB → 3 fragments
+            f.write(os.urandom(fragment_size * 3))
 
-        # Create a small file that fits in a single fragment (no splitting)
+        # small_file.bin: 1KB → fits in one fragment, accumulated into small-file batch
         small_file_path = os.path.join(temp_dir.name, "small_file.bin")
         with open(small_file_path, "wb") as f:
             f.write(os.urandom(1024))
 
-        # Create a subdirectory with a file that also gets split
+        # subdir/split_file.bin: 512KB → 2 fragments, goes through uploadFragments (1 tx)
         subdir_path = os.path.join(temp_dir.name, "subdir")
         os.makedirs(subdir_path)
         with open(os.path.join(subdir_path, "split_file.bin"), "wb") as f:
-            f.write(os.urandom(fragment_size * 2))  # 512KB → 2 fragments
+            f.write(os.urandom(fragment_size * 2))
 
         self.log.info(
             "Uploading fragmented directory '%s' with fragment_size=%d",
@@ -253,9 +259,14 @@ class DirectoryUploadDownloadTest(ClientTestFramework):
 
         self.log.info("Root hash: %s", root_hash)
 
-        # 3 fragments (large_file) + 1 (small_file) + 2 fragments (split_file) + 1 metadata = 7
+        # Processing order (alphabetical): large_file → small_file → subdir/split_file
+        #   large_file.bin:      flush empty pending (0 tx) + uploadFragments 3 frags = 1 tx
+        #   small_file.bin:      accumulated into pending batch
+        #   subdir/split_file:   flush pending (1 file) = 1 tx + uploadFragments 2 frags = 1 tx
+        #   metadata:            1 tx
+        # Total: 4 submissions
         wait_until(
-            lambda: self.contract.num_submissions() == submission_count + 7,
+            lambda: self.contract.num_submissions() == submission_count + 4,
             timeout=120,
         )
 
@@ -286,21 +297,21 @@ class DirectoryUploadDownloadTest(ClientTestFramework):
 
         temp_dir = tempfile.TemporaryDirectory(dir=self.root_dir)
 
-        # Create a file larger than fragment size — will be encrypted then split
+        # large_enc.bin: 512KB + 17B header = 524305B → 3 fragments (1 tx)
         large_file_path = os.path.join(temp_dir.name, "large_enc.bin")
         with open(large_file_path, "wb") as f:
-            f.write(os.urandom(fragment_size * 2))  # 512KB → 2 fragments after encryption
+            f.write(os.urandom(fragment_size * 2))
 
-        # Create a small file that fits in one fragment after encryption
+        # small_enc.bin: 2KB + 17B = 2065B → small, accumulated into pending batch
         small_file_path = os.path.join(temp_dir.name, "small_enc.bin")
         with open(small_file_path, "wb") as f:
             f.write(os.urandom(2048))
 
-        # Create a subdirectory with a split file
+        # subdir/nested_enc.bin: 768KB + 17B = 786449B → 4 fragments (1 tx)
         subdir_path = os.path.join(temp_dir.name, "subdir")
         os.makedirs(subdir_path)
         with open(os.path.join(subdir_path, "nested_enc.bin"), "wb") as f:
-            f.write(os.urandom(fragment_size * 3))  # 768KB → 3 fragments after encryption
+            f.write(os.urandom(fragment_size * 3))
 
         self.log.info(
             "Uploading encrypted+fragmented directory '%s'", temp_dir.name
@@ -320,14 +331,14 @@ class DirectoryUploadDownloadTest(ClientTestFramework):
 
         self.log.info("Root hash: %s", root_hash)
 
-        # Encryption adds 17-byte header, which may push fragment count up by 1
-        # large_enc: ~512KB + 17B encrypted → 3 fragments (crosses 2-segment boundary)
-        # small_enc: ~2KB + 17B → 1 fragment
-        # nested_enc: ~768KB + 17B encrypted → 4 fragments (crosses 3-segment boundary)
-        # metadata: 1 fragment
-        # Total: 3 + 1 + 4 + 1 = 9
+        # Processing order (alphabetical): large_enc → small_enc → subdir/nested_enc
+        #   large_enc.bin:       flush empty pending (0 tx) + uploadFragments 3 frags = 1 tx
+        #   small_enc.bin:       accumulated into pending batch
+        #   subdir/nested_enc:   flush pending (1 file) = 1 tx + uploadFragments 4 frags = 1 tx
+        #   metadata:            1 tx
+        # Total: 4 submissions
         wait_until(
-            lambda: self.contract.num_submissions() >= submission_count + 9,
+            lambda: self.contract.num_submissions() == submission_count + 4,
             timeout=120,
         )
 
@@ -352,6 +363,66 @@ class DirectoryUploadDownloadTest(ClientTestFramework):
 
         self.log.info("Encrypted+fragmented directory upload/download test passed")
 
+    def __test_batched_directory(self):
+        """Test that small files are batched together — N files with batch_size=B
+        produces ceil(N/B) + 1 (metadata) transactions instead of N + 1."""
+        batch_size = 2
+        num_files = 6  # ceil(6/2) = 3 batch txs + 1 metadata = 4 total
+
+        temp_dir = tempfile.TemporaryDirectory(dir=self.root_dir)
+
+        for i in range(num_files):
+            file_path = os.path.join(temp_dir.name, "file_%02d.bin" % i)
+            with open(file_path, "wb") as f:
+                f.write(os.urandom(random.randint(512, 4096)))
+
+        self.log.info(
+            "Uploading directory '%s' with %d small files, batch_size=%d",
+            temp_dir.name,
+            num_files,
+            batch_size,
+        )
+
+        submission_count = self.contract.num_submissions()
+
+        root_hash = self._upload_directory_use_cli(
+            self.blockchain_nodes[0].rpc_url,
+            GENESIS_ACCOUNT.key,
+            ",".join([x.rpc_url for x in self.nodes]),
+            None,
+            temp_dir,
+            batch_size=batch_size,
+        )
+
+        self.log.info("Root hash: %s", root_hash)
+
+        # ceil(6/2) = 3 batch txs + 1 metadata = 4 submissions
+        expected = (num_files + batch_size - 1) // batch_size + 1
+        wait_until(
+            lambda: self.contract.num_submissions() == submission_count + expected,
+            timeout=120,
+        )
+
+        for node_idx in range(4):
+            client = self.nodes[node_idx]
+            wait_until(lambda: client.zgs_get_file_info(root_hash) is not None)
+            wait_until(lambda: client.zgs_get_file_info(root_hash)["finalized"])
+
+        directory_to_download = os.path.join(self.root_dir, "download_batched")
+        self._download_directory_use_cli(
+            ",".join([x.rpc_url for x in self.nodes]),
+            None,
+            root=root_hash,
+            with_proof=True,
+            dir_to_download=directory_to_download,
+            remove=False,
+        )
+        assert directories_are_equal(
+            temp_dir.name, directory_to_download
+        ), "Batched directory content mismatch"
+
+        self.log.info("Batched directory upload/download test passed")
+
     def _upload_directory_use_cli(
         self,
         blockchain_node_rpc_url,
@@ -360,6 +431,7 @@ class DirectoryUploadDownloadTest(ClientTestFramework):
         indexer_url,
         dir_to_upload,
         fragment_size=None,
+        batch_size=None,
         skip_tx=True,
         encryption_key=None,
     ):
@@ -385,6 +457,9 @@ class DirectoryUploadDownloadTest(ClientTestFramework):
         if fragment_size is not None:
             upload_args.append("--fragment-size")
             upload_args.append(str(fragment_size))
+        if batch_size is not None:
+            upload_args.append("--batch-size")
+            upload_args.append(str(batch_size))
         if encryption_key is not None:
             upload_args.append("--encryption-key")
             upload_args.append(encryption_key)

--- a/transfer/upload_dir.go
+++ b/transfer/upload_dir.go
@@ -2,6 +2,8 @@ package transfer
 
 import (
 	"context"
+	"math"
+	"math/big"
 	"path/filepath"
 
 	"github.com/0gfoundation/0g-storage-client/core"
@@ -15,6 +17,19 @@ func (uploader *Uploader) UploadDir(ctx context.Context, folder string, option .
 	var opt UploadOption
 	if len(option) > 0 {
 		opt = option[0]
+	}
+	normalizeUploadOption(&opt)
+
+	// Align fragment size to power of 2, same as SplitableUpload.
+	fragmentSize := opt.FragmentSize
+	if fragmentSize < core.DefaultChunkSize {
+		fragmentSize = core.DefaultChunkSize
+	}
+	aligned := core.NextPow2(uint64(fragmentSize))
+	if aligned > uint64(math.MaxInt64) {
+		fragmentSize = math.MaxInt64
+	} else {
+		fragmentSize = int64(aligned)
 	}
 
 	// Build the file tree representation of the directory (roots are empty at this point).
@@ -30,34 +45,110 @@ func (uploader *Uploader) UploadDir(ctx context.Context, folder string, option .
 
 	uploader.logger.Infof("Total %d files to be uploaded", len(nodes))
 
-	// Upload each file via SplitableUpload (handles encryption + splitting).
+	// pendingDatas/Nodes/Closers accumulate small files for a single BatchUpload call.
+	pendingDatas := make([]core.IterableData, 0, opt.BatchSize)
+	pendingNodes := make([]*dir.FsNode, 0, opt.BatchSize)
+	pendingClosers := make([]func() error, 0, opt.BatchSize)
+
+	closeAll := func() {
+		for _, close := range pendingClosers {
+			close() //nolint:errcheck
+		}
+		pendingDatas = pendingDatas[:0]
+		pendingNodes = pendingNodes[:0]
+		pendingClosers = pendingClosers[:0]
+	}
+
+	// flushBatch submits all accumulated small files in a single on-chain transaction.
+	flushBatch := func() error {
+		if len(pendingDatas) == 0 {
+			return nil
+		}
+		defer closeAll()
+
+		dataOptions := make([]UploadOption, len(pendingDatas))
+		for i := range dataOptions {
+			dataOptions[i] = opt
+		}
+		batchOpt := BatchUploadOption{
+			TransactionOption: opt.TransactionOption,
+			DataOptions:       dataOptions,
+			Method:            opt.Method,
+			FullTrusted:       opt.FullTrusted,
+			TaskSize:          opt.TaskSize,
+		}
+
+		_, roots, err := uploader.BatchUpload(ctx, pendingDatas, batchOpt)
+		if err != nil {
+			return err
+		}
+
+		for i, node := range pendingNodes {
+			node.Roots = []string{roots[i].Hex()}
+			uploader.logger.WithFields(logrus.Fields{
+				"root": roots[i].Hex(),
+			}).Info("File uploaded successfully")
+		}
+		return nil
+	}
+
 	for i := range nodes {
 		path := filepath.Join(folder, relPaths[i])
+
 		file, err := core.Open(path)
 		if err != nil {
+			closeAll()
 			return txnHash, rootHash, errors.WithMessagef(err, "failed to open file %s", path)
 		}
 
-		_, roots, err := uploader.SplitableUpload(ctx, file, opt)
-		file.Close()
+		// Wrap encryption upfront for all files uniformly, before any split decision.
+		// wrapEncryption is a no-op when no key is set, and lazy (no data read) when it is.
+		encData, err := uploader.wrapEncryption(file, opt)
 		if err != nil {
-			return txnHash, rootHash, errors.WithMessagef(err, "failed to upload file %s", path)
+			file.Close()
+			closeAll()
+			return txnHash, rootHash, errors.WithMessagef(err, "failed to wrap encryption for %s", path)
 		}
 
-		// Populate the file node with actual root hashes from the upload.
-		rootStrs := make([]string, len(roots))
-		for j, r := range roots {
-			rootStrs[j] = r.Hex()
-		}
-		nodes[i].Roots = rootStrs
+		if encData.Size() <= fragmentSize {
+			// Small file: accumulate for batch upload.
+			// File handle stays open until flushBatch completes since reads are lazy.
+			pendingDatas = append(pendingDatas, encData)
+			pendingNodes = append(pendingNodes, nodes[i])
+			pendingClosers = append(pendingClosers, file.Close)
 
-		uploader.logger.WithFields(logrus.Fields{
-			"roots": rootStrs,
-			"path":  path,
-		}).Info("File uploaded successfully")
+			if uint(len(pendingDatas)) >= opt.BatchSize {
+				if err := flushBatch(); err != nil {
+					return txnHash, rootHash, errors.WithMessage(err, "failed to batch upload")
+				}
+			}
+		} else {
+			// Large file: flush pending small-file batch first, then split and upload.
+			if err := flushBatch(); err != nil {
+				file.Close()
+				return txnHash, rootHash, errors.WithMessage(err, "failed to batch upload")
+			}
+
+			rootStrs, err := uploader.uploadFragments(ctx, encData, fragmentSize, opt)
+			file.Close()
+			if err != nil {
+				return txnHash, rootHash, errors.WithMessagef(err, "failed to upload file %s", path)
+			}
+
+			nodes[i].Roots = rootStrs
+			uploader.logger.WithFields(logrus.Fields{
+				"roots": rootStrs,
+				"path":  path,
+			}).Info("File uploaded successfully")
+		}
 	}
 
-	// Serialize the updated file tree (now with roots populated).
+	// Flush any remaining small files that didn't fill a complete batch.
+	if err := flushBatch(); err != nil {
+		return txnHash, rootHash, errors.WithMessage(err, "failed to batch upload remaining files")
+	}
+
+	// Serialize the updated file tree (now with all roots populated).
 	tdata, err := root.MarshalBinary()
 	if err != nil {
 		return txnHash, rootHash, errors.WithMessage(err, "failed to encode file tree")
@@ -68,7 +159,7 @@ func (uploader *Uploader) UploadDir(ctx context.Context, folder string, option .
 		return txnHash, rootHash, errors.WithMessage(err, "failed to create `IterableData` in memory")
 	}
 
-	// Upload the directory metadata via SplitableUpload.
+	// Upload the directory metadata blob.
 	txHashes, metaRoots, err := uploader.SplitableUpload(ctx, iterdata, opt)
 	if err != nil {
 		return txnHash, rootHash, errors.WithMessage(err, "failed to upload directory metadata")
@@ -82,4 +173,54 @@ func (uploader *Uploader) UploadDir(ctx context.Context, folder string, option .
 	}
 
 	return txnHash, rootHash, nil
+}
+
+// uploadFragments splits an already-encrypted large file into fragments and submits them
+// in windows of BatchSize fragments per transaction, mirroring SplitableUpload's fragment path.
+func (uploader *Uploader) uploadFragments(ctx context.Context, data core.IterableData, fragmentSize int64, opt UploadOption) ([]string, error) {
+	fragments := data.Split(fragmentSize)
+	uploader.logger.Infof("Split large file into %d fragments", len(fragments))
+
+	totalSize := data.Size()
+	rootStrs := make([]string, 0, len(fragments))
+
+	for l := 0; l < len(fragments); l += int(opt.BatchSize) {
+		r := min(l+int(opt.BatchSize), len(fragments))
+
+		txOpt := opt.TransactionOption
+		txOpt.Nonce = nil // let each batch auto-assign nonce
+		if txOpt.Fee != nil {
+			// Apportion fee proportionally to this batch's share of total data.
+			var batchSize int64
+			for j := l; j < r; j++ {
+				batchSize += fragments[j].Size()
+			}
+			txOpt.Fee = new(big.Int).Div(
+				new(big.Int).Mul(opt.Fee, big.NewInt(batchSize)),
+				big.NewInt(totalSize),
+			)
+		}
+
+		dataOptions := make([]UploadOption, r-l)
+		for j := range dataOptions {
+			dataOptions[j] = opt
+		}
+		batchOpt := BatchUploadOption{
+			TransactionOption: txOpt,
+			DataOptions:       dataOptions,
+			Method:            opt.Method,
+			FullTrusted:       opt.FullTrusted,
+			TaskSize:          opt.TaskSize,
+		}
+
+		_, roots, err := uploader.BatchUpload(ctx, fragments[l:r], batchOpt)
+		if err != nil {
+			return nil, err
+		}
+		for _, root := range roots {
+			rootStrs = append(rootStrs, root.Hex())
+		}
+	}
+
+	return rootStrs, nil
 }


### PR DESCRIPTION
Small files (size <= fragment-size) are now grouped into batches and submitted in a single on-chain transaction per batch-size files, instead of one transaction per file. Large files are split into fragments first and each file is still handled individually. The --batch-size flag controls both: files per tx for small files in a directory, and fragments per tx for large files.

Update tests to reflect new submission counts and add a dedicated batching test. Update --batch-size flag description and cli.md docs.