### PR TITLE
feat: add ECIES (asymmetric) encryption alongside symmetric AES-256

### DIFF
--- a/cmd/download.go
+++ b/cmd/download.go
@@ -31,6 +31,7 @@ type downloadArgument struct {
 	proof bool
 
 	encryptionKey string
+	decrypt       bool
 
 	routines int
 
@@ -54,7 +55,8 @@ func bindDownloadFlags(cmd *cobra.Command, args *downloadArgument) {
 
 	cmd.Flags().BoolVar(&args.proof, "proof", false, "Whether to download with merkle proof for validation")
 
-	cmd.Flags().StringVar(&args.encryptionKey, "encryption-key", "", "Hex-encoded 32-byte AES-256 encryption key for file decryption")
+	cmd.Flags().StringVar(&args.encryptionKey, "encryption-key", "", "Hex-encoded 32-byte AES-256 symmetric key for v1 decryption (mutually exclusive with --decrypt)")
+	cmd.Flags().BoolVar(&args.decrypt, "decrypt", false, "Decrypt v2 (ECIES) files using --private-key as the wallet private key (mutually exclusive with --encryption-key)")
 
 	cmd.Flags().IntVar(&args.routines, "routines", runtime.GOMAXPROCS(0), "number of go routines for downloading simultaneously")
 
@@ -96,6 +98,12 @@ func download(*cobra.Command, []string) {
 	} else if downloadArgs.indexer == "" && len(downloadArgs.nodes) == 0 {
 		logrus.Fatal("one of --indexer, --node, or --hot-router is required")
 	}
+	if downloadArgs.decrypt && downloadArgs.encryptionKey != "" {
+		logrus.Fatal("--decrypt and --encryption-key are mutually exclusive")
+	}
+	if downloadArgs.decrypt && downloadArgs.privateKey == "" {
+		logrus.Fatal("--decrypt requires --private-key")
+	}
 
 	var (
 		downloader transfer.IDownloader
@@ -118,6 +126,9 @@ func download(*cobra.Command, []string) {
 			keyBytes := mustDecodeEncryptionKey(downloadArgs.encryptionKey)
 			indexerClient.WithEncryptionKey(keyBytes)
 		}
+		if downloadArgs.decrypt && downloadArgs.hotRouter == "" {
+			indexerClient.WithWalletPrivateKey(mustParsePrivateKey(downloadArgs.privateKey))
+		}
 		baseDownloader = indexerClient
 	} else if len(downloadArgs.nodes) > 0 {
 		clients := node.MustNewZgsClients(downloadArgs.nodes, nil, providerOption)
@@ -138,6 +149,9 @@ func download(*cobra.Command, []string) {
 			keyBytes := mustDecodeEncryptionKey(downloadArgs.encryptionKey)
 			downloaderImpl.WithEncryptionKey(keyBytes)
 		}
+		if downloadArgs.decrypt && downloadArgs.hotRouter == "" {
+			downloaderImpl.WithWalletPrivateKey(mustParsePrivateKey(downloadArgs.privateKey))
+		}
 		baseDownloader = downloaderImpl
 		defer closer()
 	}
@@ -150,6 +164,9 @@ func download(*cobra.Command, []string) {
 		if downloadArgs.encryptionKey != "" {
 			keyBytes := mustDecodeEncryptionKey(downloadArgs.encryptionKey)
 			hotDownloader.WithEncryptionKey(keyBytes)
+		}
+		if downloadArgs.decrypt {
+			hotDownloader.WithWalletPrivateKey(privateKey)
 		}
 		downloader = hotDownloader
 	} else {

--- a/cmd/download_dir.go
+++ b/cmd/download_dir.go
@@ -36,6 +36,13 @@ func downloadDir(*cobra.Command, []string) {
 		defer cancel()
 	}
 
+	if downloadDirArgs.decrypt && downloadDirArgs.encryptionKey != "" {
+		logrus.Fatal("--decrypt and --encryption-key are mutually exclusive")
+	}
+	if downloadDirArgs.decrypt && downloadDirArgs.privateKey == "" {
+		logrus.Fatal("--decrypt requires --private-key")
+	}
+
 	var downloader transfer.IDownloader
 	if downloadDirArgs.indexer != "" {
 		indexerClient, err := indexer.NewClient(downloadDirArgs.indexer, indexer.IndexerClientOption{
@@ -56,6 +63,9 @@ func downloadDir(*cobra.Command, []string) {
 				logrus.Fatal("Encryption key must be exactly 32 bytes (64 hex characters)")
 			}
 			indexerClient.WithEncryptionKey(keyBytes)
+		}
+		if downloadDirArgs.decrypt {
+			indexerClient.WithWalletPrivateKey(mustParsePrivateKey(downloadDirArgs.privateKey))
 		}
 		downloader = indexerClient
 	} else {
@@ -82,6 +92,9 @@ func downloadDir(*cobra.Command, []string) {
 				logrus.Fatal("Encryption key must be exactly 32 bytes (64 hex characters)")
 			}
 			downloaderImpl.WithEncryptionKey(keyBytes)
+		}
+		if downloadDirArgs.decrypt {
+			downloaderImpl.WithWalletPrivateKey(mustParsePrivateKey(downloadDirArgs.privateKey))
 		}
 		downloader = downloaderImpl
 		defer closer()

--- a/cmd/kv_write.go
+++ b/cmd/kv_write.go
@@ -2,8 +2,10 @@ package cmd
 
 import (
 	"context"
+	"crypto/ecdsa"
 	"math"
 	"math/big"
+	"strings"
 	"time"
 
 	zg_common "github.com/0gfoundation/0g-storage-client/common"
@@ -14,6 +16,7 @@ import (
 	"github.com/0gfoundation/0g-storage-client/transfer"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -44,6 +47,7 @@ var (
 		fullTrusted   bool
 		timeout       time.Duration
 		encryptionKey string
+		encrypt       bool
 	}
 
 	kvWriteCmd = &cobra.Command{
@@ -85,7 +89,8 @@ func init() {
 	kvWriteCmd.Flags().UintVar(&kvWriteArgs.nonce, "nonce", 0, "nonce of upload transaction")
 	kvWriteCmd.Flags().StringVar(&kvWriteArgs.method, "method", "random", "method for selecting nodes, can be max, min, random, or positive number, if provided a number, will fail if the requirement cannot be met")
 	kvWriteCmd.Flags().BoolVar(&kvWriteArgs.fullTrusted, "full-trusted", false, "whether all selected nodes should be from trusted nodes")
-	kvWriteCmd.Flags().StringVar(&kvWriteArgs.encryptionKey, "encryption-key", "", "Hex-encoded 32-byte AES-256 encryption key for encrypting the stream data")
+	kvWriteCmd.Flags().StringVar(&kvWriteArgs.encryptionKey, "encryption-key", "", "Hex-encoded 32-byte AES-256 symmetric key (v1, mutually exclusive with --encrypt)")
+	kvWriteCmd.Flags().BoolVar(&kvWriteArgs.encrypt, "encrypt", false, "Encrypt stream data with ECIES using --key's wallet pubkey (v2, mutually exclusive with --encryption-key)")
 
 	rootCmd.AddCommand(kvWriteCmd)
 }
@@ -114,6 +119,9 @@ func kvWrite(*cobra.Command, []string) {
 	if kvWriteArgs.finalityRequired {
 		finalityRequired = transfer.FileFinalized
 	}
+	if kvWriteArgs.encrypt && kvWriteArgs.encryptionKey != "" {
+		logrus.Fatal("--encrypt and --encryption-key are mutually exclusive")
+	}
 	var encryptionKey []byte
 	if kvWriteArgs.encryptionKey != "" {
 		var err error
@@ -125,12 +133,21 @@ func kvWrite(*cobra.Command, []string) {
 			logrus.Fatalf("Encryption key must be 32 bytes, got %d", len(encryptionKey))
 		}
 	}
+	var recipientPubKey *ecdsa.PublicKey
+	if kvWriteArgs.encrypt {
+		priv, err := crypto.HexToECDSA(strings.TrimPrefix(kvWriteArgs.key, "0x"))
+		if err != nil {
+			logrus.WithError(err).Fatal("Failed to parse --key for ECIES encryption")
+		}
+		recipientPubKey = &priv.PublicKey
+	}
 	opt := transfer.UploadOption{
 		TransactionOption: transfer.TransactionOption{
 			Fee:   fee,
 			Nonce: nonce,
 		},
 		EncryptionKey:    encryptionKey,
+		RecipientPubKey:  recipientPubKey,
 		FinalityRequired: finalityRequired,
 		TaskSize:         kvWriteArgs.taskSize,
 		ExpectedReplica:  kvWriteArgs.expectedReplica,

--- a/cmd/upload.go
+++ b/cmd/upload.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"crypto/ecdsa"
 	"math/big"
 	"runtime"
 	"strings"
@@ -14,6 +15,7 @@ import (
 	"github.com/0gfoundation/0g-storage-client/transfer"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -66,6 +68,7 @@ type uploadArgument struct {
 	timeout time.Duration
 
 	encryptionKey string
+	encrypt       bool
 
 	flowAddress   string
 	marketAddress string
@@ -101,7 +104,8 @@ func bindUploadFlags(cmd *cobra.Command, args *uploadArgument) {
 
 	cmd.Flags().DurationVar(&args.timeout, "timeout", 0, "cli task timeout, 0 for no timeout")
 
-	cmd.Flags().StringVar(&args.encryptionKey, "encryption-key", "", "Hex-encoded 32-byte AES-256 encryption key for file encryption")
+	cmd.Flags().StringVar(&args.encryptionKey, "encryption-key", "", "Hex-encoded 32-byte AES-256 symmetric encryption key (v1, mutually exclusive with --encrypt)")
+	cmd.Flags().BoolVar(&args.encrypt, "encrypt", false, "Encrypt file with ECIES using --key's wallet pubkey; decryptable only with the same private key (v2, mutually exclusive with --encryption-key)")
 
 	cmd.Flags().StringVar(&args.flowAddress, "flow-address", "", "Flow contract address (skip storage node status call when set)")
 	cmd.Flags().StringVar(&args.marketAddress, "market-address", "", "Market contract address (optional, skip flow lookup when set)")
@@ -168,6 +172,9 @@ func upload(*cobra.Command, []string) {
 	if uploadArgs.maxGasPrice > 0 {
 		maxGasPrice = big.NewInt(int64(uploadArgs.maxGasPrice))
 	}
+	if uploadArgs.encrypt && uploadArgs.encryptionKey != "" {
+		logrus.Fatal("--encrypt and --encryption-key are mutually exclusive")
+	}
 	var encryptionKey []byte
 	if uploadArgs.encryptionKey != "" {
 		var err error
@@ -178,6 +185,14 @@ func upload(*cobra.Command, []string) {
 		if len(encryptionKey) != 32 {
 			logrus.Fatal("Encryption key must be exactly 32 bytes (64 hex characters)")
 		}
+	}
+	var recipientPubKey *ecdsa.PublicKey
+	if uploadArgs.encrypt {
+		priv, err := crypto.HexToECDSA(strings.TrimPrefix(uploadArgs.key, "0x"))
+		if err != nil {
+			logrus.WithError(err).Fatal("Failed to parse --key for ECIES encryption")
+		}
+		recipientPubKey = &priv.PublicKey
 	}
 
 	opt := transfer.UploadOption{
@@ -191,6 +206,7 @@ func upload(*cobra.Command, []string) {
 		},
 		Tags:             hexutil.MustDecode(uploadArgs.tags),
 		EncryptionKey:    encryptionKey,
+		RecipientPubKey:  recipientPubKey,
 		FinalityRequired: finalityRequired,
 		TaskSize:         uploadArgs.taskSize,
 		ExpectedReplica:  uploadArgs.expectedReplica,

--- a/cmd/upload_dir.go
+++ b/cmd/upload_dir.go
@@ -2,12 +2,15 @@ package cmd
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"strings"
 
 	zg_common "github.com/0gfoundation/0g-storage-client/common"
 	"github.com/0gfoundation/0g-storage-client/common/blockchain"
 	"github.com/0gfoundation/0g-storage-client/transfer"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -62,6 +65,9 @@ func uploadDir(*cobra.Command, []string) {
 	if uploadDirArgs.finalityRequired {
 		finalityRequired = transfer.FileFinalized
 	}
+	if uploadDirArgs.encrypt && uploadDirArgs.encryptionKey != "" {
+		logrus.Fatal("--encrypt and --encryption-key are mutually exclusive")
+	}
 	var encryptionKey []byte
 	if uploadDirArgs.encryptionKey != "" {
 		var err error
@@ -73,12 +79,21 @@ func uploadDir(*cobra.Command, []string) {
 			logrus.Fatal("Encryption key must be exactly 32 bytes (64 hex characters)")
 		}
 	}
+	var recipientPubKey *ecdsa.PublicKey
+	if uploadDirArgs.encrypt {
+		priv, err := crypto.HexToECDSA(strings.TrimPrefix(uploadDirArgs.key, "0x"))
+		if err != nil {
+			logrus.WithError(err).Fatal("Failed to parse --key for ECIES encryption")
+		}
+		recipientPubKey = &priv.PublicKey
+	}
 	opt := transfer.UploadOption{
 		TransactionOption: transfer.TransactionOption{
 			Submitter: submitter,
 		},
 		Tags:             hexutil.MustDecode(uploadDirArgs.tags),
 		EncryptionKey:    encryptionKey,
+		RecipientPubKey:  recipientPubKey,
 		FinalityRequired: finalityRequired,
 		TaskSize:         uploadDirArgs.taskSize,
 		ExpectedReplica:  uploadDirArgs.expectedReplica,

--- a/core/ecies.go
+++ b/core/ecies.go
@@ -1,0 +1,81 @@
+package core
+
+import (
+	"crypto/ecdsa"
+	"crypto/sha256"
+	"fmt"
+	"io"
+
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/crypto/ecies"
+	"golang.org/x/crypto/hkdf"
+)
+
+// EphemeralPubKeySize is the size of a compressed secp256k1 public key (33 bytes).
+const EphemeralPubKeySize = 33
+
+// eciesHKDFInfo binds the derived key to this protocol so the same ECDH secret
+// used elsewhere won't collide with our AES key derivation.
+var eciesHKDFInfo = []byte("0g-storage-client/ecies/v1/aes-256")
+
+// DeriveECIESEncryptKey generates a fresh ephemeral secp256k1 keypair, performs ECDH with
+// recipientPub, runs the shared secret through HKDF-SHA256, and returns a 32-byte AES key
+// plus the compressed ephemeral public key (to be stored in the file header).
+func DeriveECIESEncryptKey(recipientPub *ecdsa.PublicKey) (key [32]byte, ephemeralPub [EphemeralPubKeySize]byte, err error) {
+	ephemeralPriv, err := crypto.GenerateKey()
+	if err != nil {
+		return key, ephemeralPub, fmt.Errorf("failed to generate ephemeral key: %w", err)
+	}
+
+	shared, err := eciesShared(ephemeralPriv, recipientPub)
+	if err != nil {
+		return key, ephemeralPub, err
+	}
+
+	if err := hkdfExpand(shared, key[:]); err != nil {
+		return key, ephemeralPub, err
+	}
+
+	copy(ephemeralPub[:], crypto.CompressPubkey(&ephemeralPriv.PublicKey))
+	return key, ephemeralPub, nil
+}
+
+// DeriveECIESDecryptKey recovers the AES key from the recipient's private key and the
+// compressed ephemeral public key stored in the file header.
+func DeriveECIESDecryptKey(recipientPriv *ecdsa.PrivateKey, ephemeralPub [EphemeralPubKeySize]byte) (key [32]byte, err error) {
+	pub, err := crypto.DecompressPubkey(ephemeralPub[:])
+	if err != nil {
+		return key, fmt.Errorf("failed to decompress ephemeral pubkey: %w", err)
+	}
+
+	shared, err := eciesShared(recipientPriv, pub)
+	if err != nil {
+		return key, err
+	}
+
+	if err := hkdfExpand(shared, key[:]); err != nil {
+		return key, err
+	}
+	return key, nil
+}
+
+// eciesShared runs the ECDH step via go-ethereum's ecies package, returning the raw
+// 32-byte shared secret (x-coordinate of the shared point).
+func eciesShared(priv *ecdsa.PrivateKey, pub *ecdsa.PublicKey) ([]byte, error) {
+	eciesPriv := ecies.ImportECDSA(priv)
+	eciesPub := ecies.ImportECDSAPublic(pub)
+	shared, err := eciesPriv.GenerateShared(eciesPub, 32, 0)
+	if err != nil {
+		return nil, fmt.Errorf("ecdh failed: %w", err)
+	}
+	return shared, nil
+}
+
+// hkdfExpand runs HKDF-SHA256 over the shared secret and fills out with derived bytes.
+func hkdfExpand(shared, out []byte) error {
+	reader := hkdf.New(sha256.New, shared, nil, eciesHKDFInfo)
+	if _, err := io.ReadFull(reader, out); err != nil {
+		return fmt.Errorf("hkdf expand failed: %w", err)
+	}
+	return nil
+}

--- a/core/ecies_test.go
+++ b/core/ecies_test.go
@@ -1,0 +1,50 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestECIESDeriveKeyRoundtrip(t *testing.T) {
+	recipientPriv, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	encKey, ephemeralPub, err := DeriveECIESEncryptKey(&recipientPriv.PublicKey)
+	require.NoError(t, err)
+
+	decKey, err := DeriveECIESDecryptKey(recipientPriv, ephemeralPub)
+	require.NoError(t, err)
+
+	assert.Equal(t, encKey, decKey, "encrypt key and decrypt key should match after ECDH+HKDF")
+}
+
+func TestECIESDeriveEncryptKeyFreshEphemeral(t *testing.T) {
+	recipientPriv, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	_, ephA, err := DeriveECIESEncryptKey(&recipientPriv.PublicKey)
+	require.NoError(t, err)
+
+	_, ephB, err := DeriveECIESEncryptKey(&recipientPriv.PublicKey)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, ephA, ephB, "each call must generate a fresh ephemeral keypair")
+}
+
+func TestECIESDeriveDecryptKeyWrongPrivateKeyProducesDifferentKey(t *testing.T) {
+	recipientPriv, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	attackerPriv, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	encKey, ephemeralPub, err := DeriveECIESEncryptKey(&recipientPriv.PublicKey)
+	require.NoError(t, err)
+
+	wrongKey, err := DeriveECIESDecryptKey(attackerPriv, ephemeralPub)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, encKey, wrongKey)
+}

--- a/core/encrypted_data.go
+++ b/core/encrypted_data.go
@@ -1,7 +1,9 @@
 package core
 
+import "crypto/ecdsa"
+
 // EncryptedData wraps an IterableData with AES-256-CTR encryption.
-// It prepends a 17-byte encryption header (version + nonce) to the data stream
+// It prepends the encryption header (v1: 17 bytes, v2: 50 bytes) to the data stream
 // and encrypts the inner data on-the-fly during reads.
 type EncryptedData struct {
 	inner         IterableData
@@ -13,23 +15,36 @@ type EncryptedData struct {
 
 var _ IterableData = (*EncryptedData)(nil)
 
-// NewEncryptedData creates an EncryptedData wrapper around the given data source.
+// NewEncryptedData creates a v1 (symmetric) EncryptedData wrapper around the given data source.
 // A random nonce is generated for the encryption header.
 func NewEncryptedData(inner IterableData, key [32]byte) (*EncryptedData, error) {
 	header, err := NewEncryptionHeader()
 	if err != nil {
 		return nil, err
 	}
-	encryptedSize := inner.Size() + int64(EncryptionHeaderSize)
-	paddedSize := IteratorPaddedSize(encryptedSize, true)
+	return newEncryptedData(inner, key, header), nil
+}
 
+// NewEncryptedDataECIES creates a v2 (asymmetric) EncryptedData wrapper. A fresh ephemeral
+// keypair is generated, ECDH+HKDF derives the AES key, and the ephemeral pubkey is stored
+// in the header so a recipient with recipientPub's private key can recover the AES key.
+func NewEncryptedDataECIES(inner IterableData, recipientPub *ecdsa.PublicKey) (*EncryptedData, error) {
+	header, key, err := NewECIESEncryptionHeader(recipientPub)
+	if err != nil {
+		return nil, err
+	}
+	return newEncryptedData(inner, key, header), nil
+}
+
+func newEncryptedData(inner IterableData, key [32]byte, header *EncryptionHeader) *EncryptedData {
+	encryptedSize := inner.Size() + int64(header.Size())
 	return &EncryptedData{
 		inner:         inner,
 		key:           key,
 		header:        header,
 		encryptedSize: encryptedSize,
-		paddedSize:    paddedSize,
-	}, nil
+		paddedSize:    IteratorPaddedSize(encryptedSize, true),
+	}
 }
 
 // Header returns the encryption header containing the version and nonce.
@@ -65,7 +80,7 @@ func (ed *EncryptedData) Read(buf []byte, offset int64) (int, error) {
 		return 0, nil
 	}
 
-	headerSize := int64(EncryptionHeaderSize)
+	headerSize := int64(ed.header.Size())
 	written := 0
 
 	// If offset falls within the header region

--- a/core/encrypted_data_test.go
+++ b/core/encrypted_data_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -25,7 +26,7 @@ func TestEncryptedDataSize(t *testing.T) {
 	encrypted, err := NewEncryptedData(inner, key)
 	require.NoError(t, err)
 
-	assert.Equal(t, inner.Size()+int64(EncryptionHeaderSize), encrypted.Size())
+	assert.Equal(t, inner.Size()+int64(SymmetricHeaderSize), encrypted.Size())
 }
 
 func TestEncryptedDataReadHeader(t *testing.T) {
@@ -44,12 +45,90 @@ func TestEncryptedDataReadHeader(t *testing.T) {
 	require.NoError(t, err)
 
 	// Read just the header
-	buf := make([]byte, EncryptionHeaderSize)
+	buf := make([]byte, SymmetricHeaderSize)
 	n, err := encrypted.Read(buf, 0)
 	require.NoError(t, err)
-	assert.Equal(t, EncryptionHeaderSize, n)
-	assert.Equal(t, byte(EncryptionVersion), buf[0])
+	assert.Equal(t, SymmetricHeaderSize, n)
+	assert.Equal(t, byte(SymmetricVersion), buf[0])
 	assert.Equal(t, encrypted.Header().Nonce[:], buf[1:17])
+}
+
+func TestEncryptedDataECIESFragmentRoundtrip(t *testing.T) {
+	// Produce an encrypted stream large enough to split into fragments, then decrypt
+	// fragment-by-fragment exactly the way the downloader does.
+	original := make([]byte, 500)
+	for i := range original {
+		original[i] = byte(i * 7)
+	}
+	inner, err := NewDataInMemory(original)
+	require.NoError(t, err)
+
+	recipientPriv, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	encrypted, err := NewEncryptedDataECIES(inner, &recipientPriv.PublicKey)
+	require.NoError(t, err)
+
+	// Split into fragments and read each one.
+	fragments := encrypted.Split(200) // encryptedSize = 500 + 50 = 550 -> fragments of 200, 200, 150
+	require.Len(t, fragments, 3)
+
+	fragmentBytes := make([][]byte, len(fragments))
+	for i, f := range fragments {
+		buf := make([]byte, f.Size())
+		n, err := f.Read(buf, 0)
+		require.NoError(t, err)
+		require.Equal(t, int(f.Size()), n)
+		fragmentBytes[i] = buf
+	}
+
+	// Recipient side: parse header from fragment 0, derive key, decrypt each fragment.
+	header, err := ParseEncryptionHeader(fragmentBytes[0])
+	require.NoError(t, err)
+	aesKey, err := DeriveECIESDecryptKey(recipientPriv, header.EphemeralPub)
+	require.NoError(t, err)
+
+	var recovered []byte
+	var offset uint64
+	for i, fb := range fragmentBytes {
+		plaintext, newOffset, err := DecryptFragmentData(&aesKey, header, fb, i == 0, offset)
+		require.NoError(t, err)
+		recovered = append(recovered, plaintext...)
+		offset = newOffset
+	}
+	assert.Equal(t, original, recovered)
+}
+
+func TestEncryptedDataECIESRoundtrip(t *testing.T) {
+	original := []byte("hello world encryption test with ECIES self-encryption path")
+	inner, err := NewDataInMemory(original)
+	require.NoError(t, err)
+
+	recipientPriv, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	encrypted, err := NewEncryptedDataECIES(inner, &recipientPriv.PublicKey)
+	require.NoError(t, err)
+
+	assert.Equal(t, inner.Size()+int64(ECIESHeaderSize), encrypted.Size())
+	assert.Equal(t, uint8(ECIESVersion), encrypted.Header().Version)
+
+	// Read full encrypted stream
+	encryptedSize := int(encrypted.Size())
+	encryptedBuf := make([]byte, encryptedSize)
+	n, err := encrypted.Read(encryptedBuf, 0)
+	require.NoError(t, err)
+	assert.Equal(t, encryptedSize, n)
+
+	// Recipient re-derives the AES key from their private key + the header's ephemeral pubkey
+	header, err := ParseEncryptionHeader(encryptedBuf)
+	require.NoError(t, err)
+	aesKey, err := DeriveECIESDecryptKey(recipientPriv, header.EphemeralPub)
+	require.NoError(t, err)
+
+	decrypted, err := DecryptFile(&aesKey, encryptedBuf)
+	require.NoError(t, err)
+	assert.Equal(t, original, decrypted)
 }
 
 func TestEncryptedDataRoundtrip(t *testing.T) {
@@ -251,7 +330,7 @@ func TestEncryptedDataSplitDecryptRoundtrip(t *testing.T) {
 	}
 
 	// Decrypt fragments using DecryptFragmentData (simulates download decryption)
-	header, err := ParseEncryptionHeader(fragmentDatas[0][:EncryptionHeaderSize])
+	header, err := ParseEncryptionHeader(fragmentDatas[0][:SymmetricHeaderSize])
 	require.NoError(t, err)
 
 	decrypted := make([]byte, 0)
@@ -331,7 +410,7 @@ func TestEncryptedDataSplitMultipleSizes(t *testing.T) {
 					fragmentDatas[i] = buf[:n]
 				}
 
-				header, err := ParseEncryptionHeader(fragmentDatas[0][:EncryptionHeaderSize])
+				header, err := ParseEncryptionHeader(fragmentDatas[0][:SymmetricHeaderSize])
 				require.NoError(t, err)
 
 				decrypted := make([]byte, 0)
@@ -361,7 +440,7 @@ func TestEncryptedDataOneByteRoundtrip(t *testing.T) {
 	encrypted, err := NewEncryptedData(inner, key)
 	require.NoError(t, err)
 
-	assert.Equal(t, int64(1+EncryptionHeaderSize), encrypted.Size())
+	assert.Equal(t, int64(1+SymmetricHeaderSize), encrypted.Size())
 
 	// Read full encrypted stream
 	buf := make([]byte, int(encrypted.Size()))
@@ -404,7 +483,7 @@ func TestEncryptedDataReadPastEnd(t *testing.T) {
 func TestEncryptedDataExactFragmentBoundary(t *testing.T) {
 	// Choose data size so encrypted size (data + 17) exactly equals fragment size
 	fragSize := int64(256)
-	dataSize := int(fragSize - int64(EncryptionHeaderSize)) // 239 bytes
+	dataSize := int(fragSize - int64(SymmetricHeaderSize)) // 239 bytes
 
 	original := make([]byte, dataSize)
 	for i := range original {

--- a/core/encryption.go
+++ b/core/encryption.go
@@ -3,60 +3,120 @@ package core
 import (
 	"crypto/aes"
 	"crypto/cipher"
+	"crypto/ecdsa"
 	"crypto/rand"
 	"encoding/binary"
 	"fmt"
 )
 
 const (
-	// EncryptionHeaderSize is the size of the encryption header in bytes (1 byte version + 16 bytes nonce).
-	EncryptionHeaderSize = 17
+	// SymmetricVersion identifies v1 headers: user-supplied 32-byte AES-256-CTR key.
+	SymmetricVersion = 1
+	// SymmetricHeaderSize is the v1 header size: 1 byte version + 16 bytes nonce.
+	SymmetricHeaderSize = 17
 
-	// EncryptionVersion is the current encryption format version.
-	EncryptionVersion = 1
+	// ECIESVersion identifies v2 headers: ECIES over secp256k1 with AES-256-CTR bulk cipher.
+	ECIESVersion = 2
+	// ECIESHeaderSize is the v2 header size: 1 byte version + 33 bytes compressed ephemeral pubkey + 16 bytes nonce.
+	ECIESHeaderSize = 1 + EphemeralPubKeySize + 16
 )
 
-// EncryptionHeader stores the version and nonce for AES-256-CTR encryption.
+// EncryptionHeader stores the metadata needed to decrypt a file.
+//
+//	v1 (SymmetricVersion): Version + Nonce only. Caller supplies the AES-256 key out-of-band.
+//	v2 (ECIESVersion):     Version + EphemeralPub + Nonce. Caller derives the AES-256 key
+//	                       from a recipient private key via DeriveECIESDecryptKey.
 type EncryptionHeader struct {
-	Version uint8
-	Nonce   [16]byte
+	Version      uint8
+	Nonce        [16]byte
+	EphemeralPub [EphemeralPubKeySize]byte // zero for v1
 }
 
-// NewEncryptionHeader creates a new encryption header with a random nonce.
+// NewEncryptionHeader creates a v1 header with a random nonce.
 func NewEncryptionHeader() (*EncryptionHeader, error) {
 	var nonce [16]byte
 	if _, err := rand.Read(nonce[:]); err != nil {
 		return nil, fmt.Errorf("failed to generate random nonce: %w", err)
 	}
 	return &EncryptionHeader{
-		Version: EncryptionVersion,
+		Version: SymmetricVersion,
 		Nonce:   nonce,
 	}, nil
 }
 
-// ParseEncryptionHeader extracts an encryption header from the given data.
+// NewECIESEncryptionHeader creates a v2 header for the given recipient public key and
+// returns both the header (to be serialized into the encrypted stream) and the 32-byte
+// AES key the caller must use with CryptAt.
+func NewECIESEncryptionHeader(recipientPub *ecdsa.PublicKey) (*EncryptionHeader, [32]byte, error) {
+	var emptyKey [32]byte
+	var nonce [16]byte
+	if _, err := rand.Read(nonce[:]); err != nil {
+		return nil, emptyKey, fmt.Errorf("failed to generate random nonce: %w", err)
+	}
+	aesKey, ephemeralPub, err := DeriveECIESEncryptKey(recipientPub)
+	if err != nil {
+		return nil, emptyKey, err
+	}
+	return &EncryptionHeader{
+		Version:      ECIESVersion,
+		Nonce:        nonce,
+		EphemeralPub: ephemeralPub,
+	}, aesKey, nil
+}
+
+// ParseEncryptionHeader extracts an encryption header from the given data. The caller
+// may then call Size() to learn how many header bytes to skip before the ciphertext.
 func ParseEncryptionHeader(data []byte) (*EncryptionHeader, error) {
-	if len(data) < EncryptionHeaderSize {
-		return nil, fmt.Errorf("data too short for encryption header: %d < %d", len(data), EncryptionHeaderSize)
+	if len(data) < 1 {
+		return nil, fmt.Errorf("data too short for encryption header: %d", len(data))
 	}
 	version := data[0]
-	if version != EncryptionVersion {
+	switch version {
+	case SymmetricVersion:
+		if len(data) < SymmetricHeaderSize {
+			return nil, fmt.Errorf("data too short for v1 encryption header: %d < %d", len(data), SymmetricHeaderSize)
+		}
+		h := &EncryptionHeader{Version: version}
+		copy(h.Nonce[:], data[1:17])
+		return h, nil
+	case ECIESVersion:
+		if len(data) < ECIESHeaderSize {
+			return nil, fmt.Errorf("data too short for v2 encryption header: %d < %d", len(data), ECIESHeaderSize)
+		}
+		h := &EncryptionHeader{Version: version}
+		copy(h.EphemeralPub[:], data[1:1+EphemeralPubKeySize])
+		copy(h.Nonce[:], data[1+EphemeralPubKeySize:1+EphemeralPubKeySize+16])
+		return h, nil
+	default:
 		return nil, fmt.Errorf("unsupported encryption version: %d", version)
 	}
-	var nonce [16]byte
-	copy(nonce[:], data[1:17])
-	return &EncryptionHeader{
-		Version: version,
-		Nonce:   nonce,
-	}, nil
 }
 
-// ToBytes serializes the header to a fixed-size byte array.
-func (h *EncryptionHeader) ToBytes() [EncryptionHeaderSize]byte {
-	var buf [EncryptionHeaderSize]byte
-	buf[0] = h.Version
-	copy(buf[1:17], h.Nonce[:])
-	return buf
+// Size returns the on-wire size of this header (17 for v1, 50 for v2).
+func (h *EncryptionHeader) Size() int {
+	switch h.Version {
+	case ECIESVersion:
+		return ECIESHeaderSize
+	default:
+		return SymmetricHeaderSize
+	}
+}
+
+// ToBytes serializes the header. Length depends on Version (see Size).
+func (h *EncryptionHeader) ToBytes() []byte {
+	switch h.Version {
+	case ECIESVersion:
+		buf := make([]byte, ECIESHeaderSize)
+		buf[0] = h.Version
+		copy(buf[1:1+EphemeralPubKeySize], h.EphemeralPub[:])
+		copy(buf[1+EphemeralPubKeySize:], h.Nonce[:])
+		return buf
+	default:
+		buf := make([]byte, SymmetricHeaderSize)
+		buf[0] = h.Version
+		copy(buf[1:17], h.Nonce[:])
+		return buf
+	}
 }
 
 // CryptAt encrypts or decrypts data in-place at a given byte offset within the plaintext stream.
@@ -109,15 +169,13 @@ func addToCounter(counter []byte, val uint64) {
 // DecryptFile decrypts a full downloaded file: strips the header and decrypts the remaining bytes.
 // Returns the decrypted data without the header.
 func DecryptFile(key *[32]byte, encrypted []byte) ([]byte, error) {
-	if len(encrypted) < EncryptionHeaderSize {
-		return nil, fmt.Errorf("encrypted data too short")
-	}
 	header, err := ParseEncryptionHeader(encrypted)
 	if err != nil {
 		return nil, err
 	}
-	data := make([]byte, len(encrypted)-EncryptionHeaderSize)
-	copy(data, encrypted[EncryptionHeaderSize:])
+	headerSize := header.Size()
+	data := make([]byte, len(encrypted)-headerSize)
+	copy(data, encrypted[headerSize:])
 	CryptAt(key, &header.Nonce, 0, data)
 	return data, nil
 }
@@ -129,11 +187,12 @@ func DecryptFile(key *[32]byte, encrypted []byte) ([]byte, error) {
 // Returns the decrypted plaintext and the updated cumulative data offset.
 func DecryptFragmentData(key *[32]byte, header *EncryptionHeader, fragmentData []byte, isFirstFragment bool, dataOffset uint64) ([]byte, uint64, error) {
 	if isFirstFragment {
-		if len(fragmentData) < EncryptionHeaderSize {
+		headerSize := header.Size()
+		if len(fragmentData) < headerSize {
 			return nil, 0, fmt.Errorf("first fragment too short for encryption header: %d bytes", len(fragmentData))
 		}
-		dataBytes := make([]byte, len(fragmentData)-EncryptionHeaderSize)
-		copy(dataBytes, fragmentData[EncryptionHeaderSize:])
+		dataBytes := make([]byte, len(fragmentData)-headerSize)
+		copy(dataBytes, fragmentData[headerSize:])
 		CryptAt(key, &header.Nonce, 0, dataBytes)
 		return dataBytes, uint64(len(dataBytes)), nil
 	}

--- a/core/encryption_test.go
+++ b/core/encryption_test.go
@@ -3,6 +3,7 @@ package core
 import (
 	"testing"
 
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -12,11 +13,49 @@ func TestHeaderRoundtrip(t *testing.T) {
 	require.NoError(t, err)
 
 	bytes := header.ToBytes()
-	parsed, err := ParseEncryptionHeader(bytes[:])
+	assert.Equal(t, SymmetricHeaderSize, len(bytes), "v1 header must serialize to 17 bytes")
+
+	parsed, err := ParseEncryptionHeader(bytes)
 	require.NoError(t, err)
 
-	assert.Equal(t, uint8(EncryptionVersion), parsed.Version)
+	assert.Equal(t, uint8(SymmetricVersion), parsed.Version)
 	assert.Equal(t, header.Nonce, parsed.Nonce)
+	assert.Equal(t, SymmetricHeaderSize, parsed.Size())
+}
+
+func TestECIESHeaderRoundtrip(t *testing.T) {
+	recipientPriv, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	header, _, err := NewECIESEncryptionHeader(&recipientPriv.PublicKey)
+	require.NoError(t, err)
+
+	bytes := header.ToBytes()
+	assert.Equal(t, ECIESHeaderSize, len(bytes), "v2 header must serialize to 50 bytes")
+
+	parsed, err := ParseEncryptionHeader(bytes)
+	require.NoError(t, err)
+
+	assert.Equal(t, uint8(ECIESVersion), parsed.Version)
+	assert.Equal(t, header.Nonce, parsed.Nonce)
+	assert.Equal(t, header.EphemeralPub, parsed.EphemeralPub)
+	assert.Equal(t, ECIESHeaderSize, parsed.Size())
+}
+
+func TestParseEncryptionHeaderUnsupportedVersion(t *testing.T) {
+	data := make([]byte, 17)
+	data[0] = 0xEE
+	_, err := ParseEncryptionHeader(data)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported encryption version")
+}
+
+func TestParseEncryptionHeaderV2TooShort(t *testing.T) {
+	data := make([]byte, 17)
+	data[0] = ECIESVersion
+	_, err := ParseEncryptionHeader(data)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "too short")
 }
 
 func TestCryptRoundtrip(t *testing.T) {
@@ -80,7 +119,7 @@ func TestDecryptFileTooShort(t *testing.T) {
 func TestDecryptFileWrongVersion(t *testing.T) {
 	key := [32]byte{}
 	// Header with wrong version byte (0xFF), followed by 16 nonce bytes + 1 data byte
-	data := make([]byte, EncryptionHeaderSize+1)
+	data := make([]byte, SymmetricHeaderSize+1)
 	data[0] = 0xFF // wrong version
 	_, err := DecryptFile(&key, data)
 	assert.Error(t, err)
@@ -89,7 +128,7 @@ func TestDecryptFileWrongVersion(t *testing.T) {
 
 func TestDecryptFragmentDataFirstFragmentTooShort(t *testing.T) {
 	key := [32]byte{}
-	header := &EncryptionHeader{Version: EncryptionVersion}
+	header := &EncryptionHeader{Version: SymmetricVersion}
 	// First fragment shorter than header size
 	_, _, err := DecryptFragmentData(&key, header, []byte{0x01}, true, 0)
 	assert.Error(t, err)
@@ -112,7 +151,7 @@ func TestDecryptFile(t *testing.T) {
 	CryptAt(&key, &header.Nonce, 0, encryptedData)
 
 	headerBytes := header.ToBytes()
-	encryptedFile := make([]byte, 0, EncryptionHeaderSize+len(encryptedData))
+	encryptedFile := make([]byte, 0, SymmetricHeaderSize+len(encryptedData))
 	encryptedFile = append(encryptedFile, headerBytes[:]...)
 	encryptedFile = append(encryptedFile, encryptedData...)
 

--- a/indexer/client.go
+++ b/indexer/client.go
@@ -2,6 +2,7 @@ package indexer
 
 import (
 	"context"
+	"crypto/ecdsa"
 	"fmt"
 	"io"
 	"os"
@@ -29,9 +30,10 @@ var (
 // Client indexer client
 type Client struct {
 	*rpc.Client
-	option        IndexerClientOption
-	logger        *logrus.Logger
-	encryptionKey []byte // optional 32-byte AES-256 decryption key
+	option           IndexerClientOption
+	logger           *logrus.Logger
+	encryptionKey    []byte            // optional 32-byte AES-256 decryption key (v1 symmetric)
+	walletPrivateKey *ecdsa.PrivateKey // optional wallet private key for ECIES v2 decryption
 }
 
 // IndexerClientOption indexer client option
@@ -322,15 +324,25 @@ func (c *Client) NewDownloaderFromIndexerNodes(ctx context.Context, root string)
 	return downloader, nil
 }
 
-// WithEncryptionKey sets the encryption key for post-download decryption.
+// WithEncryptionKey sets the v1 symmetric encryption key for post-download decryption.
 // The key must be exactly 32 bytes (AES-256).
 func (c *Client) WithEncryptionKey(key []byte) *Client {
 	c.encryptionKey = key
 	return c
 }
 
+// WithWalletPrivateKey sets the wallet private key used to decrypt v2 (ECIES) files.
+func (c *Client) WithWalletPrivateKey(priv *ecdsa.PrivateKey) *Client {
+	c.walletPrivateKey = priv
+	return c
+}
+
+func (c *Client) hasDecryptionKey() bool {
+	return len(c.encryptionKey) > 0 || c.walletPrivateKey != nil
+}
+
 func (c *Client) DownloadFragments(ctx context.Context, roots []string, filename string, withProof bool) error {
-	if len(c.encryptionKey) > 0 {
+	if c.hasDecryptionKey() {
 		return c.downloadEncryptedFragments(ctx, roots, filename, withProof)
 	}
 	return c.downloadPlainFragments(ctx, roots, filename, withProof)
@@ -376,12 +388,6 @@ func (c *Client) downloadPlainFragments(ctx context.Context, roots []string, fil
 // extracts the encryption header from fragment 0, then decrypts each fragment
 // with proper CTR offset tracking and writes decrypted data to the output file.
 func (c *Client) downloadEncryptedFragments(ctx context.Context, roots []string, filename string, withProof bool) error {
-	if len(c.encryptionKey) != 32 {
-		return errors.New("encryption key must be 32 bytes")
-	}
-	var key [32]byte
-	copy(key[:], c.encryptionKey)
-
 	outFile, err := os.Create(filename)
 	if err != nil {
 		return errors.WithMessage(err, "failed to create output file")
@@ -389,6 +395,7 @@ func (c *Client) downloadEncryptedFragments(ctx context.Context, roots []string,
 	defer outFile.Close()
 
 	var header *core.EncryptionHeader
+	var key [32]byte
 	var cumulativeDataOffset uint64
 
 	for i, root := range roots {
@@ -411,10 +418,14 @@ func (c *Client) downloadEncryptedFragments(ctx context.Context, roots []string,
 		os.Remove(tempFile)
 
 		if i == 0 {
-			// First fragment: extract header
+			// First fragment: extract header and resolve the AES key
 			header, err = core.ParseEncryptionHeader(fragmentData)
 			if err != nil {
 				return errors.WithMessage(err, "Failed to parse encryption header from fragment 0")
+			}
+			key, err = transfer.ResolveDecryptionKey(c.encryptionKey, c.walletPrivateKey, header)
+			if err != nil {
+				return err
 			}
 		}
 
@@ -441,6 +452,9 @@ func (c *Client) Download(ctx context.Context, root, filename string, withProof 
 	}
 	if len(c.encryptionKey) > 0 {
 		downloader.WithEncryptionKey(c.encryptionKey)
+	}
+	if c.walletPrivateKey != nil {
+		downloader.WithWalletPrivateKey(c.walletPrivateKey)
 	}
 	return downloader.Download(ctx, root, filename, withProof)
 }

--- a/tests/cli_file_ecies_upload_download_test.py
+++ b/tests/cli_file_ecies_upload_download_test.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+
+import os
+import random
+import tempfile
+
+from config.node_config import GENESIS_ACCOUNT
+from utility.utils import (
+    wait_until,
+)
+from client_test_framework.test_framework import ClientTestFramework
+
+
+def _hex_key(k) -> str:
+    """Accept either hex string or bytes; return 0x-prefixed hex string."""
+    if isinstance(k, (bytes, bytearray)):
+        return "0x" + k.hex()
+    s = str(k)
+    return s if s.startswith("0x") else "0x" + s
+
+
+class FileECIESUploadDownloadTest(ClientTestFramework):
+    def setup_params(self):
+        self.num_blockchain_nodes = 1
+        self.num_nodes = 4
+        self.zgs_node_configs[0] = {
+            "db_max_num_sectors": 2**30,
+            "shard_position": "0/4",
+        }
+        self.zgs_node_configs[1] = {
+            "db_max_num_sectors": 2**30,
+            "shard_position": "1/4",
+        }
+        self.zgs_node_configs[2] = {
+            "db_max_num_sectors": 2**30,
+            "shard_position": "2/4",
+        }
+        self.zgs_node_configs[3] = {
+            "db_max_num_sectors": 2**30,
+            "shard_position": "3/4",
+        }
+
+    def run_test(self):
+        # Sizes span: small, chunk boundaries, segment boundaries, cross-fragment.
+        data_size = [
+            2,
+            255,
+            256,
+            1023,
+            1024,
+            1025,
+            256 * 1024,
+            256 * 1024 * 10,
+        ]
+
+        for i, v in enumerate(data_size):
+            self.__test_ecies_upload_download_file(v, i + 1)
+
+    def __test_ecies_upload_download_file(self, size, submission_index):
+        self.log.info("ECIES encrypted file size: %d", size)
+
+        file_to_upload = tempfile.NamedTemporaryFile(dir=self.root_dir, delete=False)
+        data = random.randbytes(size)
+        file_to_upload.write(data)
+        file_to_upload.close()
+
+        # Self-encryption: the same wallet private key (GENESIS_ACCOUNT.key) is used
+        # both to sign the on-chain tx (via --key) and, on download, to derive the
+        # ECIES AES key (via --private-key + --decrypt).
+        priv_hex = _hex_key(GENESIS_ACCOUNT.key)
+
+        root = self._upload_file_use_cli(
+            self.blockchain_nodes[0].rpc_url,
+            GENESIS_ACCOUNT.key,
+            ",".join([x.rpc_url for x in self.nodes]),
+            None,
+            file_to_upload,
+            skip_tx=False,
+            encrypt=True,
+        )
+
+        self.log.info("root: %s", root)
+        wait_until(lambda: self.contract.num_submissions() == submission_index)
+
+        for node_idx in range(4):
+            client = self.nodes[node_idx]
+            wait_until(lambda: client.zgs_get_file_info(root) is not None)
+            wait_until(lambda: client.zgs_get_file_info(root)["finalized"])
+
+        # Download with wallet private key and verify decrypted content matches original.
+        file_to_download = os.path.join(
+            self.root_dir, "download_ecies_{}_{}".format(submission_index, size)
+        )
+        self._download_file_use_cli(
+            ",".join([x.rpc_url for x in self.nodes]),
+            None,
+            root,
+            file_to_download=file_to_download,
+            with_proof=True,
+            remove=False,
+            decrypt=True,
+            private_key=priv_hex,
+        )
+
+        with open(file_to_download, "rb") as f:
+            downloaded_data = f.read()
+        assert downloaded_data == data, "ECIES-decrypted data mismatch for size %d" % size
+        os.remove(file_to_download)
+
+        # Also test download without merkle proof.
+        self._download_file_use_cli(
+            ",".join([x.rpc_url for x in self.nodes]),
+            None,
+            root,
+            with_proof=False,
+            decrypt=True,
+            private_key=priv_hex,
+        )
+
+
+if __name__ == "__main__":
+    FileECIESUploadDownloadTest().main()

--- a/tests/client_test_framework/test_framework.py
+++ b/tests/client_test_framework/test_framework.py
@@ -119,6 +119,7 @@ class ClientTestFramework(TestFramework):
         fragment_size=None,
         skip_tx=True,
         encryption_key=None,
+        encrypt=False,
     ):
         upload_args = [
             self.cli_binary,
@@ -143,6 +144,8 @@ class ClientTestFramework(TestFramework):
         if encryption_key is not None:
             upload_args.append("--encryption-key")
             upload_args.append(encryption_key)
+        if encrypt:
+            upload_args.append("--encrypt")
 
         upload_args.append("--file")
         self.log.info("upload file with cli: {}".format(upload_args))
@@ -198,6 +201,8 @@ class ClientTestFramework(TestFramework):
         with_proof=True,
         remove=True,
         encryption_key=None,
+        decrypt=False,
+        private_key=None,
     ):
         if file_to_download is None:
             file_to_download = os.path.join(
@@ -222,6 +227,11 @@ class ClientTestFramework(TestFramework):
         if encryption_key is not None:
             download_args.append("--encryption-key")
             download_args.append(encryption_key)
+        if decrypt:
+            download_args.append("--decrypt")
+        if private_key is not None:
+            download_args.append("--private-key")
+            download_args.append(private_key)
 
         if node_rpc_url is not None:
             download_args.append("--node")

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -22,7 +22,8 @@ if __name__ == "__main__":
             "cli_dir_test.py",
         },
         single_run_tests={
-            "cli_file_encrypted_upload_download_test.py"
+            "cli_file_encrypted_upload_download_test.py",
+            "cli_file_ecies_upload_download_test.py",
         },
         long_manual_tests={},
         skip_tests={},

--- a/transfer/downloader.go
+++ b/transfer/downloader.go
@@ -2,6 +2,7 @@ package transfer
 
 import (
 	"context"
+	"crypto/ecdsa"
 	"fmt"
 	"io"
 	"os"
@@ -15,6 +16,31 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
+
+// ResolveDecryptionKey picks the correct AES key for the given header version.
+// v1 headers require a 32-byte symmetric key; v2 headers require a wallet private key
+// and derive the AES key from it and the header's ephemeral pubkey.
+func ResolveDecryptionKey(symmetricKey []byte, walletPriv *ecdsa.PrivateKey, header *core.EncryptionHeader) ([32]byte, error) {
+	var key [32]byte
+	switch header.Version {
+	case core.SymmetricVersion:
+		if len(symmetricKey) == 0 {
+			return key, errors.New("v1 encrypted file requires --encryption-key")
+		}
+		if len(symmetricKey) != 32 {
+			return key, errors.New("encryption key must be 32 bytes")
+		}
+		copy(key[:], symmetricKey)
+		return key, nil
+	case core.ECIESVersion:
+		if walletPriv == nil {
+			return key, errors.New("v2 encrypted file requires --private-key for ECIES decryption")
+		}
+		return core.DeriveECIESDecryptKey(walletPriv, header.EphemeralPub)
+	default:
+		return key, errors.Errorf("unsupported encryption version: %d", header.Version)
+	}
+}
 
 var (
 	_ IDownloader = (*Downloader)(nil)
@@ -33,7 +59,8 @@ type Downloader struct {
 
 	routines int
 
-	encryptionKey []byte // optional 32-byte AES-256 decryption key
+	encryptionKey    []byte            // optional 32-byte AES-256 decryption key (v1 symmetric)
+	walletPrivateKey *ecdsa.PrivateKey // optional wallet private key for ECIES v2 decryption
 
 	logger *logrus.Logger
 }
@@ -56,15 +83,26 @@ func (downloader *Downloader) WithRoutines(routines int) *Downloader {
 	return downloader
 }
 
-// WithEncryptionKey sets the encryption key for post-download decryption.
+// WithEncryptionKey sets the v1 symmetric encryption key for post-download decryption.
 // The key must be exactly 32 bytes (AES-256).
 func (downloader *Downloader) WithEncryptionKey(key []byte) *Downloader {
 	downloader.encryptionKey = key
 	return downloader
 }
 
+// WithWalletPrivateKey sets the wallet private key used to decrypt v2 (ECIES) encrypted files.
+func (downloader *Downloader) WithWalletPrivateKey(priv *ecdsa.PrivateKey) *Downloader {
+	downloader.walletPrivateKey = priv
+	return downloader
+}
+
+// hasDecryptionKey reports whether this downloader can attempt to decrypt an encrypted file.
+func (downloader *Downloader) hasDecryptionKey() bool {
+	return len(downloader.encryptionKey) > 0 || downloader.walletPrivateKey != nil
+}
+
 func (downloader *Downloader) DownloadFragments(ctx context.Context, roots []string, filename string, withProof bool) error {
-	if len(downloader.encryptionKey) > 0 {
+	if downloader.hasDecryptionKey() {
 		return downloader.downloadEncryptedFragments(ctx, roots, filename, withProof)
 	}
 	return downloader.downloadPlainFragments(ctx, roots, filename, withProof)
@@ -106,12 +144,6 @@ func (downloader *Downloader) downloadPlainFragments(ctx context.Context, roots 
 // extracts the encryption header from fragment 0, then decrypts each fragment
 // with proper CTR offset tracking and writes decrypted data to the output file.
 func (downloader *Downloader) downloadEncryptedFragments(ctx context.Context, roots []string, filename string, withProof bool) error {
-	if len(downloader.encryptionKey) != 32 {
-		return errors.New("encryption key must be 32 bytes")
-	}
-	var key [32]byte
-	copy(key[:], downloader.encryptionKey)
-
 	outFile, err := os.Create(filename)
 	if err != nil {
 		return errors.WithMessage(err, "failed to create output file")
@@ -119,6 +151,7 @@ func (downloader *Downloader) downloadEncryptedFragments(ctx context.Context, ro
 	defer outFile.Close()
 
 	var header *core.EncryptionHeader
+	var key [32]byte
 	var cumulativeDataOffset uint64
 
 	for i, root := range roots {
@@ -136,10 +169,14 @@ func (downloader *Downloader) downloadEncryptedFragments(ctx context.Context, ro
 		os.Remove(tempFile)
 
 		if i == 0 {
-			// First fragment: extract header
+			// First fragment: extract header and resolve the AES key from available material.
 			header, err = core.ParseEncryptionHeader(fragmentData)
 			if err != nil {
 				return errors.WithMessage(err, "Failed to parse encryption header from fragment 0")
+			}
+			key, err = ResolveDecryptionKey(downloader.encryptionKey, downloader.walletPrivateKey, header)
+			if err != nil {
+				return err
 			}
 		}
 
@@ -188,8 +225,8 @@ func (downloader *Downloader) Download(ctx context.Context, root, filename strin
 		return err
 	}
 
-	// Decrypt the file if an encryption key is set
-	if len(downloader.encryptionKey) > 0 {
+	// Decrypt the file if any decryption key is set
+	if downloader.hasDecryptionKey() {
 		if err := downloader.decryptDownloadedFile(filename); err != nil {
 			return errors.WithMessage(err, "Failed to decrypt downloaded file")
 		}
@@ -293,17 +330,21 @@ func (downloader *Downloader) validateDownloadFile(root, filename string, fileSi
 }
 
 func (downloader *Downloader) decryptDownloadedFile(filename string) error {
-	if len(downloader.encryptionKey) != 32 {
-		return errors.New("encryption key must be 32 bytes")
-	}
-
 	encrypted, err := os.ReadFile(filename)
 	if err != nil {
 		return errors.WithMessage(err, "Failed to read encrypted file")
 	}
 
-	var key [32]byte
-	copy(key[:], downloader.encryptionKey)
+	header, err := core.ParseEncryptionHeader(encrypted)
+	if err != nil {
+		return errors.WithMessage(err, "Failed to parse encryption header")
+	}
+
+	key, err := ResolveDecryptionKey(downloader.encryptionKey, downloader.walletPrivateKey, header)
+	if err != nil {
+		return err
+	}
+
 	decrypted, err := core.DecryptFile(&key, encrypted)
 	if err != nil {
 		return errors.WithMessage(err, "Failed to decrypt file")

--- a/transfer/downloader_encryption_test.go
+++ b/transfer/downloader_encryption_test.go
@@ -1,0 +1,71 @@
+package transfer
+
+import (
+	"testing"
+
+	"github.com/0gfoundation/0g-storage-client/core"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveDecryptionKeySymmetricV1(t *testing.T) {
+	header, err := core.NewEncryptionHeader()
+	require.NoError(t, err)
+
+	keyBytes := make([]byte, 32)
+	for i := range keyBytes {
+		keyBytes[i] = 0x42
+	}
+
+	got, err := ResolveDecryptionKey(keyBytes, nil, header)
+	require.NoError(t, err)
+	var want [32]byte
+	copy(want[:], keyBytes)
+	assert.Equal(t, want, got)
+}
+
+func TestResolveDecryptionKeyV1RequiresSymmetricKey(t *testing.T) {
+	header, err := core.NewEncryptionHeader()
+	require.NoError(t, err)
+
+	priv, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	_, err = ResolveDecryptionKey(nil, priv, header)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "v1")
+}
+
+func TestResolveDecryptionKeyECIESv2(t *testing.T) {
+	priv, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	header, aesKey, err := core.NewECIESEncryptionHeader(&priv.PublicKey)
+	require.NoError(t, err)
+
+	got, err := ResolveDecryptionKey(nil, priv, header)
+	require.NoError(t, err)
+	assert.Equal(t, aesKey, got, "derived key must match upload-side key")
+}
+
+func TestResolveDecryptionKeyV2RequiresPrivateKey(t *testing.T) {
+	priv, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	header, _, err := core.NewECIESEncryptionHeader(&priv.PublicKey)
+	require.NoError(t, err)
+
+	_, err = ResolveDecryptionKey(make([]byte, 32), nil, header)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "v2")
+}
+
+func TestResolveDecryptionKeyInvalidSymmetricKeyLength(t *testing.T) {
+	header, err := core.NewEncryptionHeader()
+	require.NoError(t, err)
+
+	_, err = ResolveDecryptionKey(make([]byte, 16), nil, header)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "32 bytes")
+}

--- a/transfer/hot_downloader.go
+++ b/transfer/hot_downloader.go
@@ -25,7 +25,8 @@ type HotDownloader struct {
 	privateKey   *ecdsa.PrivateKey
 	fallback     IDownloader
 
-	encryptionKey []byte
+	encryptionKey    []byte            // v1 symmetric AES-256 key
+	walletPrivateKey *ecdsa.PrivateKey // set to enable v2 ECIES decryption (typically same value as privateKey)
 
 	logger *logrus.Logger
 }
@@ -40,10 +41,21 @@ func NewHotDownloader(routerClient *node.HotRouterClient, privateKey *ecdsa.Priv
 	}
 }
 
-// WithEncryptionKey sets the encryption key for post-download decryption.
+// WithEncryptionKey sets the v1 symmetric encryption key for post-download decryption.
 func (d *HotDownloader) WithEncryptionKey(key []byte) *HotDownloader {
 	d.encryptionKey = key
 	return d
+}
+
+// WithWalletPrivateKey enables v2 (ECIES) decryption using the given private key.
+// Typically this is the same value passed to NewHotDownloader for router signing.
+func (d *HotDownloader) WithWalletPrivateKey(priv *ecdsa.PrivateKey) *HotDownloader {
+	d.walletPrivateKey = priv
+	return d
+}
+
+func (d *HotDownloader) hasDecryptionKey() bool {
+	return len(d.encryptionKey) > 0 || d.walletPrivateKey != nil
 }
 
 // Download downloads a single file, trying hot storage first and falling back to regular download.
@@ -66,7 +78,7 @@ func (d *HotDownloader) Download(ctx context.Context, root, filename string, wit
 		return d.fallback.Download(ctx, root, filename, withProof)
 	}
 
-	if len(d.encryptionKey) > 0 {
+	if d.hasDecryptionKey() {
 		if err := d.decryptFile(filename); err != nil {
 			return errors.WithMessage(err, "failed to decrypt hot storage data")
 		}
@@ -78,7 +90,7 @@ func (d *HotDownloader) Download(ctx context.Context, root, filename string, wit
 
 // DownloadFragments downloads multiple fragments, trying hot storage first per fragment.
 func (d *HotDownloader) DownloadFragments(ctx context.Context, roots []string, filename string, withProof bool) error {
-	if len(d.encryptionKey) > 0 {
+	if d.hasDecryptionKey() {
 		return d.downloadEncryptedFragments(ctx, roots, filename, withProof)
 	}
 	return d.downloadPlainFragments(ctx, roots, filename, withProof)
@@ -122,12 +134,6 @@ func (d *HotDownloader) downloadPlainFragments(ctx context.Context, roots []stri
 }
 
 func (d *HotDownloader) downloadEncryptedFragments(ctx context.Context, roots []string, filename string, withProof bool) error {
-	if len(d.encryptionKey) != 32 {
-		return errors.New("encryption key must be 32 bytes")
-	}
-	var key [32]byte
-	copy(key[:], d.encryptionKey)
-
 	outFile, err := os.Create(filename)
 	if err != nil {
 		return errors.WithMessage(err, "failed to create output file")
@@ -135,6 +141,7 @@ func (d *HotDownloader) downloadEncryptedFragments(ctx context.Context, roots []
 	defer outFile.Close()
 
 	var header *core.EncryptionHeader
+	var key [32]byte
 	var cumulativeDataOffset uint64
 
 	for i, root := range roots {
@@ -147,6 +154,10 @@ func (d *HotDownloader) downloadEncryptedFragments(ctx context.Context, roots []
 			header, err = core.ParseEncryptionHeader(fragmentData)
 			if err != nil {
 				return errors.WithMessage(err, "failed to parse encryption header from fragment 0")
+			}
+			key, err = ResolveDecryptionKey(d.encryptionKey, d.walletPrivateKey, header)
+			if err != nil {
+				return err
 			}
 		}
 
@@ -240,14 +251,20 @@ func (d *HotDownloader) tryHotDownloadToFile(ctx context.Context, root, path str
 	return ok, err
 }
 
-// decryptFile decrypts the file at filename in-place using the downloader's encryption key.
+// decryptFile decrypts the file at filename in-place, auto-detecting v1 vs v2 from its header.
 func (d *HotDownloader) decryptFile(filename string) error {
 	data, err := os.ReadFile(filename)
 	if err != nil {
 		return errors.WithMessage(err, "failed to read file for decryption")
 	}
-	var key [32]byte
-	copy(key[:], d.encryptionKey)
+	header, err := core.ParseEncryptionHeader(data)
+	if err != nil {
+		return errors.WithMessage(err, "failed to parse encryption header")
+	}
+	key, err := ResolveDecryptionKey(d.encryptionKey, d.walletPrivateKey, header)
+	if err != nil {
+		return err
+	}
 	decrypted, err := core.DecryptFile(&key, data)
 	if err != nil {
 		return errors.WithMessage(err, "failed to decrypt file")

--- a/transfer/uploader.go
+++ b/transfer/uploader.go
@@ -2,6 +2,7 @@ package transfer
 
 import (
 	"context"
+	"crypto/ecdsa"
 	"fmt"
 	"math"
 	"math/big"
@@ -60,8 +61,9 @@ type UploadOption struct {
 	TransactionOption
 
 	// Data options
-	Tags          []byte // transaction tags
-	EncryptionKey []byte // optional 32-byte AES-256 encryption key; when set, data is encrypted before upload
+	Tags            []byte           // transaction tags
+	EncryptionKey   []byte           // optional 32-byte AES-256 encryption key (v1 symmetric); mutually exclusive with RecipientPubKey
+	RecipientPubKey *ecdsa.PublicKey // optional recipient secp256k1 pubkey (v2 ECIES); mutually exclusive with EncryptionKey
 
 	// Upload behavior
 	FinalityRequired FinalityRequirement // finality setting
@@ -167,8 +169,22 @@ func NewUploaderWithContractConfig(ctx context.Context, w3Client *web3go.Client,
 	return uploader, nil
 }
 
-// wrapEncryption wraps data with AES-256-CTR encryption if an encryption key is provided.
+// wrapEncryption wraps data with AES-256-CTR encryption.
+// If EncryptionKey is set: v1 symmetric header, caller-supplied 32-byte key.
+// If RecipientPubKey is set: v2 ECIES header, AES key derived via ECDH+HKDF.
+// Both set is an error.
 func (uploader *Uploader) wrapEncryption(data core.IterableData, opt UploadOption) (core.IterableData, error) {
+	if len(opt.EncryptionKey) > 0 && opt.RecipientPubKey != nil {
+		return nil, errors.New("EncryptionKey and RecipientPubKey are mutually exclusive")
+	}
+	if opt.RecipientPubKey != nil {
+		encData, err := core.NewEncryptedDataECIES(data, opt.RecipientPubKey)
+		if err != nil {
+			return nil, errors.WithMessage(err, "Failed to create ECIES encrypted data")
+		}
+		uploader.logger.Info("Data encryption enabled (ECIES)")
+		return encData, nil
+	}
 	if len(opt.EncryptionKey) == 0 {
 		return data, nil
 	}

--- a/transfer/uploader_encryption_test.go
+++ b/transfer/uploader_encryption_test.go
@@ -1,0 +1,66 @@
+package transfer
+
+import (
+	"testing"
+
+	"github.com/0gfoundation/0g-storage-client/core"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWrapEncryptionNoKeyPassthrough(t *testing.T) {
+	uploader := &Uploader{logger: logrus.New()}
+	data, err := core.NewDataInMemory([]byte("hello"))
+	require.NoError(t, err)
+
+	wrapped, err := uploader.wrapEncryption(data, UploadOption{})
+	require.NoError(t, err)
+	assert.Same(t, core.IterableData(data), wrapped, "no key means pass-through")
+}
+
+func TestWrapEncryptionSymmetric(t *testing.T) {
+	uploader := &Uploader{logger: logrus.New()}
+	data, err := core.NewDataInMemory([]byte("hello"))
+	require.NoError(t, err)
+	key := make([]byte, 32)
+
+	wrapped, err := uploader.wrapEncryption(data, UploadOption{EncryptionKey: key})
+	require.NoError(t, err)
+	_, ok := wrapped.(*core.EncryptedData)
+	assert.True(t, ok, "symmetric key should produce EncryptedData")
+	assert.Equal(t, data.Size()+int64(core.SymmetricHeaderSize), wrapped.Size())
+}
+
+func TestWrapEncryptionECIES(t *testing.T) {
+	uploader := &Uploader{logger: logrus.New()}
+	data, err := core.NewDataInMemory([]byte("hello"))
+	require.NoError(t, err)
+
+	priv, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	wrapped, err := uploader.wrapEncryption(data, UploadOption{RecipientPubKey: &priv.PublicKey})
+	require.NoError(t, err)
+	encData, ok := wrapped.(*core.EncryptedData)
+	require.True(t, ok)
+	assert.Equal(t, uint8(core.ECIESVersion), encData.Header().Version)
+	assert.Equal(t, data.Size()+int64(core.ECIESHeaderSize), wrapped.Size())
+}
+
+func TestWrapEncryptionMutuallyExclusive(t *testing.T) {
+	uploader := &Uploader{logger: logrus.New()}
+	data, err := core.NewDataInMemory([]byte("hello"))
+	require.NoError(t, err)
+
+	priv, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	_, err = uploader.wrapEncryption(data, UploadOption{
+		EncryptionKey:   make([]byte, 32),
+		RecipientPubKey: &priv.PublicKey,
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "mutually exclusive")
+}


### PR DESCRIPTION
Introduce a v2 encryption header format carrying a 33-byte ephemeral secp256k1 public key, enabling wallet-based self-encryption: encrypt with a private key's derived pubkey, decrypt with the same private key. The bulk cipher remains AES-256-CTR so fragment-offset decryption keeps working; only key derivation changes.

v1 (17-byte symmetric header) remains fully supported on read; new clients decrypt old files, and the existing integration test continues to pass against the new code. Format is version-dispatched at parse time, so old files never need migration.

CLI: add --encrypt (upload/upload-dir/kv-write) to opt into ECIES using the existing --key, and --decrypt (download/download-dir) to opt into ECIES using the existing --private-key. Both are mutually exclusive with the legacy --encryption-key.

Includes a new integration test exercising end-to-end ECIES across file sizes from 2 bytes to 2.6 MiB with and without Merkle proof.