### PR TITLE
Feat/s3 gateway additions

### DIFF
--- a/indexer/client.go
+++ b/indexer/client.go
@@ -5,7 +5,10 @@ import (
 	"crypto/ecdsa"
 	"fmt"
 	"io"
+	"math/big"
 	"os"
+	"sync"
+	"time"
 
 	"github.com/0gfoundation/0g-storage-client/common"
 	"github.com/0gfoundation/0g-storage-client/common/rpc"
@@ -34,6 +37,12 @@ type Client struct {
 	logger           *logrus.Logger
 	encryptionKey    []byte            // optional 32-byte AES-256 decryption key (v1 symmetric)
 	walletPrivateKey *ecdsa.PrivateKey // optional wallet private key for ECIES v2 decryption
+
+	// EstimateFee cache state. See client_estimate.go.
+	estimateMu     sync.Mutex
+	estimateTTL    time.Duration
+	estimatePrice  *big.Int
+	estimateLoaded time.Time
 }
 
 // IndexerClientOption indexer client option

--- a/indexer/client.go
+++ b/indexer/client.go
@@ -5,10 +5,7 @@ import (
 	"crypto/ecdsa"
 	"fmt"
 	"io"
-	"math/big"
 	"os"
-	"sync"
-	"time"
 
 	"github.com/0gfoundation/0g-storage-client/common"
 	"github.com/0gfoundation/0g-storage-client/common/rpc"
@@ -37,12 +34,6 @@ type Client struct {
 	logger           *logrus.Logger
 	encryptionKey    []byte            // optional 32-byte AES-256 decryption key (v1 symmetric)
 	walletPrivateKey *ecdsa.PrivateKey // optional wallet private key for ECIES v2 decryption
-
-	// EstimateFee cache state. See client_estimate.go.
-	estimateMu     sync.Mutex
-	estimateTTL    time.Duration
-	estimatePrice  *big.Int
-	estimateLoaded time.Time
 }
 
 // IndexerClientOption indexer client option

--- a/indexer/client_estimate.go
+++ b/indexer/client_estimate.go
@@ -3,7 +3,6 @@ package indexer
 import (
 	"context"
 	"math/big"
-	"time"
 
 	"github.com/0gfoundation/0g-storage-client/contract"
 	"github.com/0gfoundation/0g-storage-client/core"
@@ -20,14 +19,15 @@ import (
 // Cheaper than going through Uploader.EstimateFee: the latter requires
 // NewUploaderFromIndexerNodes (an indexer RPC + storage-node selection)
 // even though node selection has nothing to do with the fee. This path
-// only needs the market contract's pricePerSector, which we cache.
+// only needs the market contract's pricePerSector.
 //
-// fee = pricePerSector * numSectors(data, tags)
+//	fee = pricePerSector * numSectors(data, tags)
 //
 // numSectors is a pure off-chain computation derived from data size and
-// tags length. pricePerSector is read from the market contract at most
-// once per cacheTTL — by default 30s, configurable via
-// (*Client).SetEstimateCacheTTL.
+// tags length. pricePerSector is one eth_call per invocation — cheap and
+// in practice never changes (governance-gated FixedPrice.setPricePerSector
+// in 0g-storage-contracts). Callers that estimate fees on a hot path
+// should layer their own cache.
 func (c *Client) EstimateFee(ctx context.Context, w3Client *web3go.Client, marketAddr eth_common.Address, data core.IterableData, tags []byte) (*big.Int, error) {
 	flow := core.NewFlow(data, tags)
 	submission, err := flow.CreateSubmission(eth_common.Address{})
@@ -35,54 +35,17 @@ func (c *Client) EstimateFee(ctx context.Context, w3Client *web3go.Client, marke
 		return nil, errors.WithMessage(err, "create flow submission")
 	}
 
-	pricePerSector, err := c.cachedPricePerSector(ctx, w3Client, marketAddr)
-	if err != nil {
-		return nil, err
-	}
-
-	return submission.Fee(pricePerSector), nil
-}
-
-// SetEstimateCacheTTL configures how long EstimateFee caches the
-// market-contract pricePerSector read. Default 30s. Pass 0 to disable
-// caching (re-read on every call).
-func (c *Client) SetEstimateCacheTTL(d time.Duration) {
-	c.estimateMu.Lock()
-	defer c.estimateMu.Unlock()
-	c.estimateTTL = d
-}
-
-func (c *Client) cachedPricePerSector(ctx context.Context, w3Client *web3go.Client, marketAddr eth_common.Address) (*big.Int, error) {
-	c.estimateMu.Lock()
-	ttl := c.estimateTTL
-	if ttl == 0 {
-		ttl = 30 * time.Second
-	}
-	if c.estimatePrice != nil && time.Since(c.estimateLoaded) < ttl {
-		price := new(big.Int).Set(c.estimatePrice)
-		c.estimateMu.Unlock()
-		return price, nil
-	}
-	c.estimateMu.Unlock()
-
-	// Cache miss / expired — read from chain. Done outside the lock so
-	// concurrent callers don't serialize on the RPC.
 	backend, _ := w3Client.ToClientForContract()
 	market, err := contract.NewMarket(marketAddr, backend)
 	if err != nil {
 		return nil, errors.WithMessage(err, "NewMarket")
 	}
-	price, err := market.PricePerSector(&bind.CallOpts{Context: ctx})
+	pricePerSector, err := market.PricePerSector(&bind.CallOpts{Context: ctx})
 	if err != nil {
 		return nil, errors.WithMessage(err, "PricePerSector")
 	}
 
-	c.estimateMu.Lock()
-	c.estimatePrice = new(big.Int).Set(price)
-	c.estimateLoaded = time.Now()
-	c.estimateMu.Unlock()
-
-	return price, nil
+	return submission.Fee(pricePerSector), nil
 }
 
 // EstimateFeeFromUploader is provided as a fallback for callers that

--- a/indexer/client_estimate.go
+++ b/indexer/client_estimate.go
@@ -1,0 +1,93 @@
+package indexer
+
+import (
+	"context"
+	"math/big"
+	"time"
+
+	"github.com/0gfoundation/0g-storage-client/contract"
+	"github.com/0gfoundation/0g-storage-client/core"
+	"github.com/0gfoundation/0g-storage-client/transfer"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	eth_common "github.com/ethereum/go-ethereum/common"
+	"github.com/openweb3/web3go"
+	"github.com/pkg/errors"
+)
+
+// EstimateFee computes the on-chain protocol fee (in wei) that an upload
+// of `data` with `tags` would charge.
+//
+// Cheaper than going through Uploader.EstimateFee: the latter requires
+// NewUploaderFromIndexerNodes (an indexer RPC + storage-node selection)
+// even though node selection has nothing to do with the fee. This path
+// only needs the market contract's pricePerSector, which we cache.
+//
+// fee = pricePerSector * numSectors(data, tags)
+//
+// numSectors is a pure off-chain computation derived from data size and
+// tags length. pricePerSector is read from the market contract at most
+// once per cacheTTL — by default 30s, configurable via
+// (*Client).SetEstimateCacheTTL.
+func (c *Client) EstimateFee(ctx context.Context, w3Client *web3go.Client, marketAddr eth_common.Address, data core.IterableData, tags []byte) (*big.Int, error) {
+	flow := core.NewFlow(data, tags)
+	submission, err := flow.CreateSubmission(eth_common.Address{})
+	if err != nil {
+		return nil, errors.WithMessage(err, "create flow submission")
+	}
+
+	pricePerSector, err := c.cachedPricePerSector(ctx, w3Client, marketAddr)
+	if err != nil {
+		return nil, err
+	}
+
+	return submission.Fee(pricePerSector), nil
+}
+
+// SetEstimateCacheTTL configures how long EstimateFee caches the
+// market-contract pricePerSector read. Default 30s. Pass 0 to disable
+// caching (re-read on every call).
+func (c *Client) SetEstimateCacheTTL(d time.Duration) {
+	c.estimateMu.Lock()
+	defer c.estimateMu.Unlock()
+	c.estimateTTL = d
+}
+
+func (c *Client) cachedPricePerSector(ctx context.Context, w3Client *web3go.Client, marketAddr eth_common.Address) (*big.Int, error) {
+	c.estimateMu.Lock()
+	ttl := c.estimateTTL
+	if ttl == 0 {
+		ttl = 30 * time.Second
+	}
+	if c.estimatePrice != nil && time.Since(c.estimateLoaded) < ttl {
+		price := new(big.Int).Set(c.estimatePrice)
+		c.estimateMu.Unlock()
+		return price, nil
+	}
+	c.estimateMu.Unlock()
+
+	// Cache miss / expired — read from chain. Done outside the lock so
+	// concurrent callers don't serialize on the RPC.
+	backend, _ := w3Client.ToClientForContract()
+	market, err := contract.NewMarket(marketAddr, backend)
+	if err != nil {
+		return nil, errors.WithMessage(err, "NewMarket")
+	}
+	price, err := market.PricePerSector(&bind.CallOpts{Context: ctx})
+	if err != nil {
+		return nil, errors.WithMessage(err, "PricePerSector")
+	}
+
+	c.estimateMu.Lock()
+	c.estimatePrice = new(big.Int).Set(price)
+	c.estimateLoaded = time.Now()
+	c.estimateMu.Unlock()
+
+	return price, nil
+}
+
+// EstimateFeeFromUploader is provided as a fallback for callers that
+// already have an Uploader instance (e.g. they're about to upload and
+// want a final pre-flight check). Equivalent to Uploader.EstimateFee.
+func EstimateFeeFromUploader(ctx context.Context, uploader *transfer.Uploader, data core.IterableData, tags []byte) (*big.Int, error) {
+	return uploader.EstimateFee(ctx, data, tags)
+}

--- a/indexer/client_writer.go
+++ b/indexer/client_writer.go
@@ -1,0 +1,47 @@
+package indexer
+
+import (
+	"context"
+	"io"
+
+	"github.com/pkg/errors"
+)
+
+// DownloadToWriter streams a full file to w by discovering storage nodes via
+// the indexer and delegating to (*transfer.Downloader).DownloadToWriter.
+//
+// Encryption is not supported — see (*transfer.Downloader).DownloadToWriter
+// for why. Use Download(filename) for encrypted files since header parsing
+// requires buffering before any plaintext can be emitted.
+func (c *Client) DownloadToWriter(ctx context.Context, root string, w io.Writer, withProof bool) error {
+	if c.hasDecryptionKey() {
+		return errors.New("DownloadToWriter does not support encrypted files — use Download(filename) instead")
+	}
+	downloader, err := c.NewDownloaderFromIndexerNodes(ctx, root)
+	if err != nil {
+		return err
+	}
+	// Propagate encryption keys defensively even though we already
+	// rejected encrypted files above — keeps the downloader in a
+	// consistent state if the contract changes later.
+	if len(c.encryptionKey) > 0 {
+		downloader.WithEncryptionKey(c.encryptionKey)
+	}
+	if c.walletPrivateKey != nil {
+		downloader.WithWalletPrivateKey(c.walletPrivateKey)
+	}
+	return downloader.DownloadToWriter(ctx, root, w, withProof)
+}
+
+// DownloadRangeToWriter streams bytes [offset, offset+length) of `root` to w.
+// Internally discovers nodes via the indexer just like Download.
+func (c *Client) DownloadRangeToWriter(ctx context.Context, root string, offset, length int64, w io.Writer) error {
+	if c.hasDecryptionKey() {
+		return errors.New("DownloadRangeToWriter does not support encrypted files")
+	}
+	downloader, err := c.NewDownloaderFromIndexerNodes(ctx, root)
+	if err != nil {
+		return err
+	}
+	return downloader.DownloadRangeToWriter(ctx, root, offset, length, w)
+}

--- a/indexer/ip_location.go
+++ b/indexer/ip_location.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"sync"
@@ -13,6 +14,14 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
+
+// ipLocationHTTPTimeout bounds the ipinfo.io GET so indexer startup
+// can't hang on a slow / blocked external network. The Query result
+// is non-fatal (caller logs Warn and continues), so failing fast is
+// strictly an improvement.
+const ipLocationHTTPTimeout = 5 * time.Second
+
+var ipLocationHTTPClient = &http.Client{Timeout: ipLocationHTTPTimeout}
 
 var defaultIPLocationManager = IPLocationManager{}
 
@@ -78,6 +87,13 @@ func (manager *IPLocationManager) Query(ip string) (*IPLocation, error) {
 		return loc.(*IPLocation), nil
 	}
 
+	// Skip loopback / private RFC-1918 / link-local addresses. They have
+	// no useful geo info, and the lookup is the bottleneck that hangs
+	// indexer startup when ipinfo.io is slow/blocked (see #143).
+	if isNonRoutableIP(ip) {
+		return nil, nil
+	}
+
 	var url string
 	if len(manager.config.AccessToken) == 0 {
 		url = fmt.Sprintf("http://ipinfo.io/%v/json", ip)
@@ -85,7 +101,7 @@ func (manager *IPLocationManager) Query(ip string) (*IPLocation, error) {
 		url = fmt.Sprintf("http://ipinfo.io/%v/json?token=%v", ip, manager.config.AccessToken)
 	}
 
-	resp, err := http.Get(url)
+	resp, err := ipLocationHTTPClient.Get(url)
 	if err != nil {
 		return nil, errors.WithMessagef(err, "Failed to http GET from %v", url)
 	}
@@ -117,6 +133,17 @@ func (manager *IPLocationManager) Query(ip string) (*IPLocation, error) {
 	}
 
 	return &loc, nil
+}
+
+// isNonRoutableIP reports whether ip is a loopback, link-local, or
+// private RFC-1918 / ULA address — anything for which an external
+// geo-lookup against ipinfo.io would be pointless.
+func isNonRoutableIP(ip string) bool {
+	parsed := net.ParseIP(ip)
+	if parsed == nil {
+		return false // unparseable input — let the caller hit the API (or fail)
+	}
+	return parsed.IsLoopback() || parsed.IsPrivate() || parsed.IsLinkLocalUnicast() || parsed.IsLinkLocalMulticast() || parsed.IsUnspecified()
 }
 
 // read reads IP locations from cache file.

--- a/indexer/ip_location_test.go
+++ b/indexer/ip_location_test.go
@@ -1,0 +1,36 @@
+package indexer
+
+import "testing"
+
+func TestIsNonRoutableIP(t *testing.T) {
+	// Regression for #143: the indexer's startup IP-geo lookup must
+	// short-circuit for any IP where ipinfo.io has nothing useful to
+	// say, so a slow / blocked external network can't hang startup.
+	cases := []struct {
+		ip   string
+		want bool
+		desc string
+	}{
+		{"127.0.0.1", true, "IPv4 loopback"},
+		{"::1", true, "IPv6 loopback"},
+		{"10.0.0.1", true, "RFC1918 10/8"},
+		{"172.16.0.1", true, "RFC1918 172.16/12"},
+		{"172.31.255.255", true, "RFC1918 172.31 edge"},
+		{"192.168.1.1", true, "RFC1918 192.168/16"},
+		{"169.254.1.1", true, "link-local IPv4"},
+		{"fe80::1", true, "link-local IPv6"},
+		{"0.0.0.0", true, "unspecified"},
+		{"8.8.8.8", false, "public DNS"},
+		{"1.1.1.1", false, "public"},
+		{"172.32.0.1", false, "outside RFC1918 172.16/12"},
+		{"not-an-ip", false, "unparseable"},
+	}
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			got := isNonRoutableIP(c.ip)
+			if got != c.want {
+				t.Errorf("isNonRoutableIP(%q) = %v, want %v", c.ip, got, c.want)
+			}
+		})
+	}
+}

--- a/transfer/download_parallel.go
+++ b/transfer/download_parallel.go
@@ -33,8 +33,7 @@ type segmentDownloader struct {
 var _ parallel.Interface = (*segmentDownloader)(nil)
 
 func newSegmentDownloader(downloader *Downloader, info *node.FileInfo, file *download.DownloadingFile, withProof bool) (*segmentDownloader, error) {
-	startSegmentIndex := info.Tx.StartEntryIndex / core.DefaultSegmentMaxChunks
-	endSegmentIndex := (info.Tx.StartEntryIndex + core.NumSplits(int64(info.Tx.Size), core.DefaultChunkSize) - 1) / core.DefaultSegmentMaxChunks
+	startSegmentIndex, endSegmentIndex := core.SegmentRange(info.Tx.StartEntryIndex, info.Tx.Size)
 
 	logrus.WithFields(logrus.Fields{
 		"size":              info.Tx.Size,

--- a/transfer/download_parallel.go
+++ b/transfer/download_parallel.go
@@ -105,9 +105,16 @@ func (downloader *segmentDownloader) ParallelDo(ctx context.Context, routine, ta
 		// Shard-skip + RPC + (optional) proof-validation all happen
 		// inside fetchSegmentFromNode (segment_fetch.go). This is the
 		// single source of truth shared with downloader_writer.go.
-		segment, err := fetchSegmentFromNode(ctx, client, downloader.txSeq, root,
-			segmentIndex, globalSegIdx, startIndex, endIndex,
-			downloader.withProof, fileSize)
+		segment, err := fetchSegmentFromNode(ctx, client, segmentFetchRequest{
+			TxSeq:        downloader.txSeq,
+			Root:         root,
+			FileSize:     fileSize,
+			SegIdx:       segmentIndex,
+			GlobalSegIdx: globalSegIdx,
+			StartChunk:   startIndex,
+			EndChunk:     endIndex,
+			WithProof:    downloader.withProof,
+		})
 		if err != nil {
 			downloader.logger.WithError(err).WithFields(logCtx(nodeIndex)).Error("Failed to download segment")
 			continue

--- a/transfer/download_parallel.go
+++ b/transfer/download_parallel.go
@@ -8,8 +8,6 @@ import (
 	"github.com/0gfoundation/0g-storage-client/core"
 	"github.com/0gfoundation/0g-storage-client/node"
 	"github.com/0gfoundation/0g-storage-client/transfer/download"
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -89,63 +87,47 @@ func (downloader *segmentDownloader) ParallelDo(ctx context.Context, routine, ta
 	}
 
 	root := downloader.file.Metadata().Root
+	fileSize := downloader.file.Metadata().Size
+	globalSegIdx := downloader.startSegmentIndex + segmentIndex
 
-	var (
-		segment []byte
-		err     error
-	)
+	logCtx := func(nodeIndex int) logrus.Fields {
+		return logrus.Fields{
+			"node index": nodeIndex,
+			"segment":    fmt.Sprintf("%v/(%v-%v)", globalSegIdx, downloader.startSegmentIndex, downloader.endSegmentIndex),
+			"chunks":     fmt.Sprintf("[%v, %v)", startIndex, endIndex),
+		}
+	}
 
 	for i := 0; i < len(downloader.clients); i += 1 {
 		nodeIndex := (routine + i) % len(downloader.clients)
-		shardConfig := downloader.clients[nodeIndex].ShardConfig()
-		if shardConfig == nil {
-			return nil, errors.New("ShardConfig is required on ZgsClient")
-		}
-		if (downloader.startSegmentIndex+segmentIndex)%shardConfig.NumShard != shardConfig.ShardId {
-			continue
-		}
-		// try download from current node
-		if downloader.withProof {
-			segment, err = downloader.downloadWithProof(ctx, downloader.clients[nodeIndex], downloader.txSeq, root, startIndex, endIndex)
-		} else {
-			segment, err = downloader.clients[nodeIndex].DownloadSegmentByTxSeq(ctx, downloader.txSeq, startIndex, endIndex)
-		}
+		client := downloader.clients[nodeIndex]
 
+		// Shard-skip + RPC + (optional) proof-validation all happen
+		// inside fetchSegmentFromNode (segment_fetch.go). This is the
+		// single source of truth shared with downloader_writer.go.
+		segment, err := fetchSegmentFromNode(ctx, client, downloader.txSeq, root,
+			segmentIndex, globalSegIdx, startIndex, endIndex,
+			downloader.withProof, fileSize)
 		if err != nil {
-			downloader.logger.WithError(err).WithFields(logrus.Fields{
-				"node index": nodeIndex,
-				"segment":    fmt.Sprintf("%v/(%v-%v)", downloader.startSegmentIndex+segmentIndex, downloader.startSegmentIndex, downloader.endSegmentIndex),
-				"chunks":     fmt.Sprintf("[%v, %v)", startIndex, endIndex),
-			}).Error("Failed to download segment")
+			downloader.logger.WithError(err).WithFields(logCtx(nodeIndex)).Error("Failed to download segment")
 			continue
 		}
 		if segment == nil {
-			downloader.logger.WithFields(logrus.Fields{
-				"node index": nodeIndex,
-				"segment":    fmt.Sprintf("%v/(%v-%v)", downloader.startSegmentIndex+segmentIndex, downloader.startSegmentIndex, downloader.endSegmentIndex),
-				"chunks":     fmt.Sprintf("[%v, %v)", startIndex, endIndex),
-			}).Warn("segment not found")
+			// Either this node doesn't shard the segment (silent skip)
+			// or the RPC returned an empty segment. Try the next node.
+			downloader.logger.WithFields(logCtx(nodeIndex)).Debug("segment not available from this node")
 			continue
 		}
 		if len(segment)%core.DefaultChunkSize != 0 {
-			downloader.logger.WithFields(logrus.Fields{
-				"node index": nodeIndex,
-				"segment":    fmt.Sprintf("%v/(%v-%v)", downloader.startSegmentIndex+segmentIndex, downloader.startSegmentIndex, downloader.endSegmentIndex),
-				"chunks":     fmt.Sprintf("[%v, %v)", startIndex, endIndex),
-			}).Warn("invalid segment length")
+			downloader.logger.WithFields(logCtx(nodeIndex)).Warn("invalid segment length")
 			continue
 		}
 		if downloader.logger.IsLevelEnabled(logrus.DebugLevel) {
-			downloader.logger.WithFields(logrus.Fields{
-				"node index": nodeIndex,
-				"segment":    fmt.Sprintf("%v/(%v-%v)", downloader.startSegmentIndex+segmentIndex, downloader.startSegmentIndex, downloader.endSegmentIndex),
-				"chunks":     fmt.Sprintf("[%v, %v)", startIndex, endIndex),
-			}).Debug("Succeeded to download segment")
+			downloader.logger.WithFields(logCtx(nodeIndex)).Debug("Succeeded to download segment")
 		}
 
 		// remove paddings for the last chunk
-		if downloader.startSegmentIndex+segmentIndex == downloader.endSegmentIndex {
-			fileSize := downloader.file.Metadata().Size
+		if globalSegIdx == downloader.endSegmentIndex {
 			if lastChunkSize := fileSize % core.DefaultChunkSize; lastChunkSize > 0 {
 				paddings := core.DefaultChunkSize - lastChunkSize
 				segment = segment[0 : len(segment)-int(paddings)]
@@ -159,27 +141,4 @@ func (downloader *segmentDownloader) ParallelDo(ctx context.Context, routine, ta
 // ParallelCollect implements the parallel.Interface interface.
 func (downloader *segmentDownloader) ParallelCollect(result *parallel.Result) error {
 	return downloader.file.Write(result.Value.([]byte))
-}
-
-func (downloader *segmentDownloader) downloadWithProof(ctx context.Context, client *node.ZgsClient, txSeq uint64, root common.Hash, startIndex, endIndex uint64) ([]byte, error) {
-	segmentIndex := startIndex / core.DefaultSegmentMaxChunks
-
-	segment, err := client.DownloadSegmentWithProofByTxSeq(ctx, txSeq, segmentIndex)
-	if err != nil {
-		return nil, errors.WithMessage(err, "Failed to download segment with proof from storage node")
-	}
-	if segment == nil {
-		return nil, nil
-	}
-
-	if expectedDataLen := (endIndex - startIndex) * core.DefaultChunkSize; int(expectedDataLen) != len(segment.Data) {
-		return nil, errors.Errorf("Downloaded data length mismatch, expected = %v, actual = %v", expectedDataLen, len(segment.Data))
-	}
-
-	segmentRootHash, numSegmentsFlowPadded := core.PaddedSegmentRoot(segmentIndex, segment.Data, downloader.file.Metadata().Size)
-	if err := segment.Proof.ValidateHash(root, segmentRootHash, segmentIndex, numSegmentsFlowPadded); err != nil {
-		return nil, errors.WithMessage(err, "Failed to validate proof")
-	}
-
-	return segment.Data, nil
 }

--- a/transfer/downloader_writer.go
+++ b/transfer/downloader_writer.go
@@ -67,7 +67,10 @@ func (downloader *Downloader) downloadRangeToWriter(ctx context.Context, root st
 	segChunks := uint64(core.DefaultSegmentMaxChunks)
 
 	fileNumChunks := core.NumSplits(fileSize, core.DefaultChunkSize)
-	globalStartSeg := info.Tx.StartEntryIndex / segChunks
+	// Flow-wide segment index of the file's first segment — used to
+	// turn file-relative segment indices into the global indices that
+	// fetchSegmentFromNode needs for shard distribution.
+	globalStartSeg, _ := core.SegmentRange(info.Tx.StartEntryIndex, uint64(fileSize))
 
 	endByte := offset + length // exclusive
 	startChunk := uint64(offset / chunkSize)

--- a/transfer/downloader_writer.go
+++ b/transfer/downloader_writer.go
@@ -71,7 +71,7 @@ func (downloader *Downloader) downloadRangeToWriter(ctx context.Context, root st
 
 	endByte := offset + length // exclusive
 	startChunk := uint64(offset / chunkSize)
-	endChunkExcl := uint64((endByte + chunkSize - 1) / chunkSize)
+	endChunkExcl := core.NumSplits(endByte, core.DefaultChunkSize)
 	if endChunkExcl > fileNumChunks {
 		endChunkExcl = fileNumChunks
 	}

--- a/transfer/downloader_writer.go
+++ b/transfer/downloader_writer.go
@@ -1,0 +1,193 @@
+package transfer
+
+import (
+	"context"
+	"io"
+
+	"github.com/0gfoundation/0g-storage-client/core"
+	"github.com/0gfoundation/0g-storage-client/node"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/pkg/errors"
+)
+
+// DownloadToWriter streams a full file identified by `root` to w.
+//
+// Unlike Download, this avoids the temp-file disk hop — useful for HTTP
+// gateways and other consumers that want to forward bytes directly to a
+// network sink. Segments are fetched sequentially and written in order.
+//
+// Encryption is NOT supported on this path: encrypted files require buffering
+// the full ciphertext to detect the header version and resolve the AES key
+// before any plaintext can be emitted, which defeats the streaming property.
+// Use the file-based Download for encrypted files.
+func (downloader *Downloader) DownloadToWriter(ctx context.Context, root string, w io.Writer, withProof bool) error {
+	if downloader.hasDecryptionKey() {
+		return errors.New("DownloadToWriter does not support encrypted files — use Download(filename) instead")
+	}
+	return downloader.downloadRangeToWriter(ctx, root, w, 0, -1, withProof)
+}
+
+// DownloadRangeToWriter streams bytes [offset, offset+length) of `root` to w.
+//
+// length must be > 0. Use DownloadToWriter for full-file streaming. The proof
+// path is intentionally excluded: range reads are typically hot-path latency
+// reads (e.g. LanceDB manifest lookups) where re-validating merkle proofs
+// per request is overkill — full-file Download with withProof=true remains
+// the integrity-checked entry point.
+func (downloader *Downloader) DownloadRangeToWriter(ctx context.Context, root string, offset, length int64, w io.Writer) error {
+	if downloader.hasDecryptionKey() {
+		return errors.New("DownloadRangeToWriter does not support encrypted files")
+	}
+	if length <= 0 {
+		return errors.Errorf("length must be positive, got %d", length)
+	}
+	return downloader.downloadRangeToWriter(ctx, root, w, offset, length, false)
+}
+
+// downloadRangeToWriter is the shared implementation for both writer-based
+// download paths. length<0 means "to end of file".
+func (downloader *Downloader) downloadRangeToWriter(ctx context.Context, root string, w io.Writer, offset, length int64, withProof bool) error {
+	hash := common.HexToHash(root)
+	info, err := downloader.queryFile(ctx, hash)
+	if err != nil {
+		return errors.WithMessage(err, "Failed to query file info")
+	}
+
+	fileSize := int64(info.Tx.Size)
+	if length < 0 {
+		length = fileSize - offset
+	}
+	if offset < 0 || offset > fileSize || offset+length > fileSize {
+		return errors.Errorf("range out of bounds: offset=%d length=%d size=%d", offset, length, fileSize)
+	}
+	if length == 0 {
+		return nil
+	}
+
+	chunkSize := int64(core.DefaultChunkSize)
+	segChunks := uint64(core.DefaultSegmentMaxChunks)
+
+	fileNumChunks := core.NumSplits(fileSize, core.DefaultChunkSize)
+	globalStartSeg := info.Tx.StartEntryIndex / segChunks
+
+	endByte := offset + length // exclusive
+	startChunk := uint64(offset / chunkSize)
+	endChunkExcl := uint64((endByte + chunkSize - 1) / chunkSize)
+	if endChunkExcl > fileNumChunks {
+		endChunkExcl = fileNumChunks
+	}
+
+	startSeg := startChunk / segChunks
+	endSeg := (endChunkExcl - 1) / segChunks
+
+	written := int64(0)
+	for seg := startSeg; seg <= endSeg; seg++ {
+		segStartChunk := seg * segChunks
+		segEndChunk := segStartChunk + segChunks
+		if segEndChunk > fileNumChunks {
+			segEndChunk = fileNumChunks
+		}
+
+		data, err := downloader.fetchSegmentBytes(ctx, info.Tx.Seq, hash, seg, globalStartSeg+seg, segStartChunk, segEndChunk, withProof, fileSize)
+		if err != nil {
+			return errors.WithMessagef(err, "segment %d", seg)
+		}
+
+		// Trim chunk-padding from the last segment of the file. Segments are
+		// always returned chunk-aligned; the final chunk may have <256 bytes
+		// of real data and the rest is zero-padding.
+		if segEndChunk == fileNumChunks {
+			if lastChunkBytes := fileSize % chunkSize; lastChunkBytes > 0 {
+				padding := chunkSize - lastChunkBytes
+				data = data[:int64(len(data))-padding]
+			}
+		}
+
+		// Slice to the byte range within this segment we actually want.
+		segByteStart := int64(segStartChunk) * chunkSize
+		sliceLo := offset - segByteStart
+		if sliceLo < 0 {
+			sliceLo = 0
+		}
+		sliceHi := endByte - segByteStart
+		if sliceHi > int64(len(data)) {
+			sliceHi = int64(len(data))
+		}
+
+		if sliceLo < sliceHi {
+			n, werr := w.Write(data[sliceLo:sliceHi])
+			if werr != nil {
+				return errors.WithMessage(werr, "write to sink")
+			}
+			written += int64(n)
+		}
+	}
+
+	if written != length {
+		return errors.Errorf("incomplete write: got %d of %d bytes", written, length)
+	}
+	return nil
+}
+
+// fetchSegmentBytes downloads a single segment from any storage node that
+// holds it (per shard config) and validates the proof if requested. Tries
+// each client in turn; the last error wins on total failure.
+func (downloader *Downloader) fetchSegmentBytes(
+	ctx context.Context,
+	txSeq uint64,
+	root common.Hash,
+	segIdx, globalSegIdx, startChunk, endChunk uint64,
+	withProof bool,
+	fileSize int64,
+) ([]byte, error) {
+	var lastErr error
+	for i := 0; i < len(downloader.clients); i++ {
+		client := downloader.clients[i]
+		if data, err := tryFetchSegment(ctx, client, txSeq, root, segIdx, globalSegIdx, startChunk, endChunk, withProof, fileSize); err == nil {
+			if data != nil {
+				return data, nil
+			}
+		} else {
+			lastErr = err
+		}
+	}
+	if lastErr != nil {
+		return nil, errors.WithMessage(lastErr, "all nodes failed")
+	}
+	return nil, errors.Errorf("no node served segment %d", segIdx)
+}
+
+func tryFetchSegment(
+	ctx context.Context,
+	client *node.ZgsClient,
+	txSeq uint64,
+	root common.Hash,
+	segIdx, globalSegIdx, startChunk, endChunk uint64,
+	withProof bool,
+	fileSize int64,
+) ([]byte, error) {
+	if sc := client.ShardConfig(); sc != nil && sc.NumShard > 0 {
+		if globalSegIdx%sc.NumShard != sc.ShardId {
+			return nil, nil // this node doesn't shard this segment; not an error
+		}
+	}
+	if withProof {
+		sw, err := client.DownloadSegmentWithProofByTxSeq(ctx, txSeq, segIdx)
+		if err != nil {
+			return nil, err
+		}
+		if sw == nil {
+			return nil, nil
+		}
+		segRoot, numSegPad := core.PaddedSegmentRoot(segIdx, sw.Data, fileSize)
+		if err := sw.Proof.ValidateHash(root, segRoot, segIdx, numSegPad); err != nil {
+			return nil, errors.WithMessage(err, "proof validation")
+		}
+		return sw.Data, nil
+	}
+	data, err := client.DownloadSegmentByTxSeq(ctx, txSeq, startChunk, endChunk)
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
+}

--- a/transfer/downloader_writer.go
+++ b/transfer/downloader_writer.go
@@ -5,7 +5,6 @@ import (
 	"io"
 
 	"github.com/0gfoundation/0g-storage-client/core"
-	"github.com/0gfoundation/0g-storage-client/node"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/pkg/errors"
 )
@@ -130,8 +129,12 @@ func (downloader *Downloader) downloadRangeToWriter(ctx context.Context, root st
 }
 
 // fetchSegmentBytes downloads a single segment from any storage node that
-// holds it (per shard config) and validates the proof if requested. Tries
+// holds it (per shard config), validating the proof if requested. Tries
 // each client in turn; the last error wins on total failure.
+//
+// The shard-skip + fetch + validate per-node logic lives in
+// fetchSegmentFromNode (segment_fetch.go); this method is just the
+// "try each client" loop.
 func (downloader *Downloader) fetchSegmentBytes(
 	ctx context.Context,
 	txSeq uint64,
@@ -143,51 +146,17 @@ func (downloader *Downloader) fetchSegmentBytes(
 	var lastErr error
 	for i := 0; i < len(downloader.clients); i++ {
 		client := downloader.clients[i]
-		if data, err := tryFetchSegment(ctx, client, txSeq, root, segIdx, globalSegIdx, startChunk, endChunk, withProof, fileSize); err == nil {
-			if data != nil {
-				return data, nil
-			}
-		} else {
+		data, err := fetchSegmentFromNode(ctx, client, txSeq, root, segIdx, globalSegIdx, startChunk, endChunk, withProof, fileSize)
+		if err != nil {
 			lastErr = err
+			continue
+		}
+		if data != nil {
+			return data, nil
 		}
 	}
 	if lastErr != nil {
 		return nil, errors.WithMessage(lastErr, "all nodes failed")
 	}
 	return nil, errors.Errorf("no node served segment %d", segIdx)
-}
-
-func tryFetchSegment(
-	ctx context.Context,
-	client *node.ZgsClient,
-	txSeq uint64,
-	root common.Hash,
-	segIdx, globalSegIdx, startChunk, endChunk uint64,
-	withProof bool,
-	fileSize int64,
-) ([]byte, error) {
-	if sc := client.ShardConfig(); sc != nil && sc.NumShard > 0 {
-		if globalSegIdx%sc.NumShard != sc.ShardId {
-			return nil, nil // this node doesn't shard this segment; not an error
-		}
-	}
-	if withProof {
-		sw, err := client.DownloadSegmentWithProofByTxSeq(ctx, txSeq, segIdx)
-		if err != nil {
-			return nil, err
-		}
-		if sw == nil {
-			return nil, nil
-		}
-		segRoot, numSegPad := core.PaddedSegmentRoot(segIdx, sw.Data, fileSize)
-		if err := sw.Proof.ValidateHash(root, segRoot, segIdx, numSegPad); err != nil {
-			return nil, errors.WithMessage(err, "proof validation")
-		}
-		return sw.Data, nil
-	}
-	data, err := client.DownloadSegmentByTxSeq(ctx, txSeq, startChunk, endChunk)
-	if err != nil {
-		return nil, err
-	}
-	return data, nil
 }

--- a/transfer/downloader_writer.go
+++ b/transfer/downloader_writer.go
@@ -146,7 +146,16 @@ func (downloader *Downloader) fetchSegmentBytes(
 	var lastErr error
 	for i := 0; i < len(downloader.clients); i++ {
 		client := downloader.clients[i]
-		data, err := fetchSegmentFromNode(ctx, client, txSeq, root, segIdx, globalSegIdx, startChunk, endChunk, withProof, fileSize)
+		data, err := fetchSegmentFromNode(ctx, client, segmentFetchRequest{
+			TxSeq:        txSeq,
+			Root:         root,
+			FileSize:     fileSize,
+			SegIdx:       segIdx,
+			GlobalSegIdx: globalSegIdx,
+			StartChunk:   startChunk,
+			EndChunk:     endChunk,
+			WithProof:    withProof,
+		})
 		if err != nil {
 			lastErr = err
 			continue

--- a/transfer/downloader_writer_test.go
+++ b/transfer/downloader_writer_test.go
@@ -1,0 +1,83 @@
+package transfer
+
+import (
+	"testing"
+
+	"github.com/0gfoundation/0g-storage-client/core"
+)
+
+// These tests exercise the chunk + segment + slicing geometry that
+// downloadRangeToWriter relies on. The real fetch path goes through
+// storage-node RPCs (covered by integration tests against MinIO/0G
+// testnet); here we verify the boundary math in isolation.
+
+const (
+	tChunk     = core.DefaultChunkSize        // 256
+	tSegChunks = core.DefaultSegmentMaxChunks // 1024
+	tSeg       = tChunk * tSegChunks          // 262144
+)
+
+// computeRangeBounds replicates the segment-range derivation in
+// downloadRangeToWriter so the math can be tested in isolation. If the
+// implementation drifts from this helper, one or both must be updated.
+func computeRangeBounds(offset, length, fileSize int64) (startSeg, endSeg uint64, ok bool) {
+	if length < 0 {
+		length = fileSize - offset
+	}
+	if offset < 0 || offset > fileSize || offset+length > fileSize {
+		return 0, 0, false
+	}
+	if length == 0 {
+		return 0, 0, true
+	}
+	chunkSize := int64(core.DefaultChunkSize)
+	segChunks := uint64(core.DefaultSegmentMaxChunks)
+	fileNumChunks := core.NumSplits(fileSize, core.DefaultChunkSize)
+	endByte := offset + length
+	startChunk := uint64(offset / chunkSize)
+	endChunkExcl := uint64((endByte + chunkSize - 1) / chunkSize)
+	if endChunkExcl > fileNumChunks {
+		endChunkExcl = fileNumChunks
+	}
+	startSeg = startChunk / segChunks
+	endSeg = (endChunkExcl - 1) / segChunks
+	return startSeg, endSeg, true
+}
+
+func TestComputeRangeBounds_FirstSegmentOnly(t *testing.T) {
+	startSeg, endSeg, ok := computeRangeBounds(100, 50, int64(2*tSeg+1000))
+	if !ok || startSeg != 0 || endSeg != 0 {
+		t.Fatalf("got start=%d end=%d ok=%v", startSeg, endSeg, ok)
+	}
+}
+
+func TestComputeRangeBounds_CrossingSegmentBoundary(t *testing.T) {
+	off := int64(tSeg - 100)
+	startSeg, endSeg, ok := computeRangeBounds(off, 200, int64(3*tSeg))
+	if !ok || startSeg != 0 || endSeg != 1 {
+		t.Fatalf("got start=%d end=%d ok=%v", startSeg, endSeg, ok)
+	}
+}
+
+func TestComputeRangeBounds_LastSegmentRespectsFileSize(t *testing.T) {
+	fileSize := int64(2*tSeg + 100)
+	startSeg, endSeg, ok := computeRangeBounds(2*tSeg, 100, fileSize)
+	if !ok || startSeg != 2 || endSeg != 2 {
+		t.Fatalf("got start=%d end=%d ok=%v", startSeg, endSeg, ok)
+	}
+}
+
+func TestComputeRangeBounds_FullFileSentinel(t *testing.T) {
+	if _, _, ok := computeRangeBounds(0, -1, 1000); !ok {
+		t.Error("length=-1 with offset=0 should be treated as full file")
+	}
+}
+
+func TestComputeRangeBounds_RejectsOutOfBounds(t *testing.T) {
+	if _, _, ok := computeRangeBounds(-1, 10, 1000); ok {
+		t.Error("negative offset should reject")
+	}
+	if _, _, ok := computeRangeBounds(900, 200, 1000); ok {
+		t.Error("offset+length past file end should reject")
+	}
+}

--- a/transfer/segment_fetch.go
+++ b/transfer/segment_fetch.go
@@ -9,6 +9,32 @@ import (
 	"github.com/pkg/errors"
 )
 
+// segmentFetchRequest is the parameter bundle for fetchSegmentFromNode.
+// Grouped because the per-node fetch needs file-level (TxSeq, Root,
+// FileSize), segment-level (SegIdx, GlobalSegIdx, StartChunk, EndChunk),
+// and mode (WithProof) inputs — passing them as positional args was a
+// 10-arg smell.
+type segmentFetchRequest struct {
+	// Identifies the file on chain.
+	TxSeq    uint64
+	Root     common.Hash
+	FileSize int64
+
+	// Identifies the segment within the file. SegIdx is the local
+	// per-file segment index (also the index used by the proof RPC).
+	// GlobalSegIdx is the flow-wide segment index used for shard
+	// distribution math: GlobalSegIdx % NumShard == ShardId for nodes
+	// that hold this segment.
+	SegIdx       uint64
+	GlobalSegIdx uint64
+	StartChunk   uint64
+	EndChunk     uint64
+
+	// WithProof requests a Merkle proof and validates it against Root
+	// before returning the data.
+	WithProof bool
+}
+
 // fetchSegmentFromNode downloads one segment from a single ZgsClient,
 // applying the shard-config skip and (optionally) the proof validation.
 //
@@ -24,25 +50,17 @@ import (
 // Used by both download_parallel.go (file-based parallel download) and
 // downloader_writer.go (io.Writer-based streaming download) so the
 // shard-skip and proof-validation paths live in exactly one place.
-func fetchSegmentFromNode(
-	ctx context.Context,
-	client *node.ZgsClient,
-	txSeq uint64,
-	root common.Hash,
-	segIdx, globalSegIdx, startChunk, endChunk uint64,
-	withProof bool,
-	fileSize int64,
-) ([]byte, error) {
+func fetchSegmentFromNode(ctx context.Context, client *node.ZgsClient, req segmentFetchRequest) ([]byte, error) {
 	sc := client.ShardConfig()
 	if sc == nil {
 		return nil, errors.New("ShardConfig is required on ZgsClient")
 	}
-	if sc.NumShard > 0 && globalSegIdx%sc.NumShard != sc.ShardId {
+	if sc.NumShard > 0 && req.GlobalSegIdx%sc.NumShard != sc.ShardId {
 		return nil, nil // this node doesn't shard this segment; not an error
 	}
 
-	if withProof {
-		sw, err := client.DownloadSegmentWithProofByTxSeq(ctx, txSeq, segIdx)
+	if req.WithProof {
+		sw, err := client.DownloadSegmentWithProofByTxSeq(ctx, req.TxSeq, req.SegIdx)
 		if err != nil {
 			return nil, err
 		}
@@ -52,15 +70,15 @@ func fetchSegmentFromNode(
 		// Pre-validate the data length against the requested chunk range.
 		// download_parallel.go used to enforce this inline; preserve it
 		// here so both download paths get the same guarantee.
-		if expected := (endChunk - startChunk) * core.DefaultChunkSize; int(expected) != len(sw.Data) {
+		if expected := (req.EndChunk - req.StartChunk) * core.DefaultChunkSize; int(expected) != len(sw.Data) {
 			return nil, errors.Errorf("downloaded data length mismatch: expected %d, got %d", expected, len(sw.Data))
 		}
-		segRoot, numSegPad := core.PaddedSegmentRoot(segIdx, sw.Data, fileSize)
-		if err := sw.Proof.ValidateHash(root, segRoot, segIdx, numSegPad); err != nil {
+		segRoot, numSegPad := core.PaddedSegmentRoot(req.SegIdx, sw.Data, req.FileSize)
+		if err := sw.Proof.ValidateHash(req.Root, segRoot, req.SegIdx, numSegPad); err != nil {
 			return nil, errors.WithMessage(err, "proof validation")
 		}
 		return sw.Data, nil
 	}
 
-	return client.DownloadSegmentByTxSeq(ctx, txSeq, startChunk, endChunk)
+	return client.DownloadSegmentByTxSeq(ctx, req.TxSeq, req.StartChunk, req.EndChunk)
 }

--- a/transfer/segment_fetch.go
+++ b/transfer/segment_fetch.go
@@ -49,6 +49,12 @@ func fetchSegmentFromNode(
 		if sw == nil {
 			return nil, nil
 		}
+		// Pre-validate the data length against the requested chunk range.
+		// download_parallel.go used to enforce this inline; preserve it
+		// here so both download paths get the same guarantee.
+		if expected := (endChunk - startChunk) * core.DefaultChunkSize; int(expected) != len(sw.Data) {
+			return nil, errors.Errorf("downloaded data length mismatch: expected %d, got %d", expected, len(sw.Data))
+		}
 		segRoot, numSegPad := core.PaddedSegmentRoot(segIdx, sw.Data, fileSize)
 		if err := sw.Proof.ValidateHash(root, segRoot, segIdx, numSegPad); err != nil {
 			return nil, errors.WithMessage(err, "proof validation")

--- a/transfer/segment_fetch.go
+++ b/transfer/segment_fetch.go
@@ -1,0 +1,60 @@
+package transfer
+
+import (
+	"context"
+
+	"github.com/0gfoundation/0g-storage-client/core"
+	"github.com/0gfoundation/0g-storage-client/node"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/pkg/errors"
+)
+
+// fetchSegmentFromNode downloads one segment from a single ZgsClient,
+// applying the shard-config skip and (optionally) the proof validation.
+//
+// Return contract:
+//
+//   - (data, nil)  — segment fetched (and proof validated, if requested)
+//   - (nil,  nil)  — this node does not shard the requested segment, OR
+//                    the RPC returned a nil segment (treat as "not here";
+//                    caller should try the next node)
+//   - (nil,  err)  — RPC error, proof-validation error, or missing
+//                    ShardConfig on the client
+//
+// Used by both download_parallel.go (file-based parallel download) and
+// downloader_writer.go (io.Writer-based streaming download) so the
+// shard-skip and proof-validation paths live in exactly one place.
+func fetchSegmentFromNode(
+	ctx context.Context,
+	client *node.ZgsClient,
+	txSeq uint64,
+	root common.Hash,
+	segIdx, globalSegIdx, startChunk, endChunk uint64,
+	withProof bool,
+	fileSize int64,
+) ([]byte, error) {
+	sc := client.ShardConfig()
+	if sc == nil {
+		return nil, errors.New("ShardConfig is required on ZgsClient")
+	}
+	if sc.NumShard > 0 && globalSegIdx%sc.NumShard != sc.ShardId {
+		return nil, nil // this node doesn't shard this segment; not an error
+	}
+
+	if withProof {
+		sw, err := client.DownloadSegmentWithProofByTxSeq(ctx, txSeq, segIdx)
+		if err != nil {
+			return nil, err
+		}
+		if sw == nil {
+			return nil, nil
+		}
+		segRoot, numSegPad := core.PaddedSegmentRoot(segIdx, sw.Data, fileSize)
+		if err := sw.Proof.ValidateHash(root, segRoot, segIdx, numSegPad); err != nil {
+			return nil, errors.WithMessage(err, "proof validation")
+		}
+		return sw.Data, nil
+	}
+
+	return client.DownloadSegmentByTxSeq(ctx, txSeq, startChunk, endChunk)
+}


### PR DESCRIPTION
## Summary

SDK changes needed by the 0G S3 gateway: stream-to-`io.Writer` downloads, range downloads, and cheap fee estimation. Plus a string of refactor / bug fixes the gateway work surfaced.

## Commits

| Commit | What |
|---|---|
| e0aa330 | DownloadToWriter / DownloadRangeToWriter / indexer EstimateFee — initial gateway-facing additions |
| 9febd5d | drop the unused EstimateFee pricePerSector cache (over-engineered) |
| 1d22769 | extract `fetchSegmentFromNode` shared helper |
| 80ff6e9 | route `download_parallel.go` through the shared helper |
| 7f52f76 | group fetchSegmentFromNode params into a `segmentFetchRequest` struct |
| a1843ae | use `core.NumSplits` for ceil-divide in `downloader_writer.go` |
| 707eeee | route both downloaders through `core.SegmentRange` |
| b63e6b6 | indexer: don't geo-lookup loopback / private IPs, bound the HTTP call |

## Closes

- Closes #139 (tryFetchSegment dup)
- Closes #140 (NumSplits dup)
- Closes #141 (SegmentRange dup)
- Closes #143 (ipinfo.io hang in indexer startup)

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./transfer/...` `./indexer/...` green
- [x] All gateway e2e tests (26) pass with the rebuilt indexer binary; previously-recurring "indexer port not available within 60s" flake no longer reproduces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)