### PR TITLE
indexer: skip Flow.submit on retry after first submit succeeded

### DIFF
--- a/indexer/client.go
+++ b/indexer/client.go
@@ -163,6 +163,20 @@ func (c *Client) SplitableUpload(ctx context.Context, w3Client *web3go.Client, d
 			return txHashes, roots, nil
 		}
 
+		// If Flow.submit already succeeded on a previous attempt
+		// (txHashes is non-empty), tell the next iteration not to
+		// redo it — otherwise we pay storage fee + gas a second time
+		// for the same content, leaking the caller's wallet on every
+		// transient segment-upload failure. uploader.uploadSlow /
+		// uploadFast only honors opt.SkipTx when the storage node also
+		// confirms the entry is on chain (checkLogExistence != nil),
+		// so this is best-effort dedup: if the new uploader's nodes
+		// haven't synced the previous submit yet, we'll fall back to
+		// a fresh submit — no worse than today.
+		if len(txHashes) > 0 {
+			opt.SkipTx = true
+		}
+
 		if !opt.FullTrusted {
 			opt.FullTrusted = true
 			c.logger.WithError(err).Warn("Upload failed, retrying with full trusted nodes")


### PR DESCRIPTION
## What

\`Client.SplitableUpload\`'s retry loop today calls \`uploader.SplitableUpload\` with the **same** \`UploadOption\` on every iteration. If the segment-upload step fails on the first attempt (e.g. a transient \`zgs_node\` connection close mid-stream), the retry re-runs the entire pipeline — *including \`Flow.submit\`* — so the operator wallet pays storage fee + gas a second time for the same content even though the first submit's tx is already on chain.

This patch sets \`opt.SkipTx = true\` on retry iff the previous attempt returned non-empty \`txHashes\` (i.e. Flow.submit succeeded). \`uploadSlow\` / \`uploadFast\` already honor \`SkipTx\` when \`checkLogExistence\` also confirms the entry is on the storage node, so this is **best-effort dedup**: if the new uploader's nodes haven't synced the previous submit yet, we fall back to a fresh submit — no worse than today.

## Why

Surfaced via the \`0g-storage-s3\` gateway's testnet smoke. A 1 MiB PUT hit a storage-node connection close on segment 4/5, the SDK retried, and **two distinct \`Flow.submit\` txs** landed:

  - tx \`0x31ab5d1ad37e59cfd217ff63107e0ef5d5ef438e0c044f9fc9a392349c68237a\` — block 35477500, msg.value = 141,620,635,984,896 wei
  - tx \`0xb488ec7f6b846ffdfaa2ef951b8c4e4969ec48ac82a46f48779929cf8abba90f\` — block 35477646, msg.value = 141,620,635,984,896 wei

The gateway billed the *user* once (preflight reservation = 1× storage fee, correct), but the *operator wallet* was charged twice. That's a quiet leak on every transient segment-upload failure under load.

## Scope

This is a minimal, defensive change in the retry wrapper — no semantic change to \`uploadSlow\` / \`uploadFast\` / \`checkLogExistence\`. Existing callers who set \`SkipTx\` explicitly are unaffected.

## Test plan

- [x] Build + vet clean against \`origin/main\`
- [ ] Re-run the 0g-storage-s3 gateway testnet smoke and confirm a forced segment-upload failure now triggers exactly **one** Flow.submit tx (not two)
- [ ] (Follow-up if needed) Add a unit test that exercises the retry path with a mock segment-upload failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)