### PR TITLE
kv: forward-port EncodedSizeForSingleWrite + its test to main (closes #146)

### DIFF
--- a/kv/types.go
+++ b/kv/types.go
@@ -69,6 +69,23 @@ type StreamData struct {
 	Controls []accessControl
 }
 
+// EncodedSizeForSingleWrite returns the exact byte count that
+// StreamData.Encode() would produce for a stream-data blob containing
+// exactly one streamWrite (no reads, no access controls).
+//
+// Intended for pricing pre-flight on gateways that wrap the KV API:
+// the caller knows the (key, data) lengths it will submit but not yet
+// the actual bytes, and needs the encoded size to compute storage
+// cost. Mirrors (*StreamData).Size() for the single-write case —
+// kept in sync via TestEncodedSizeForSingleWriteMatchesSize.
+func EncodedSizeForSingleWrite(keyLen, dataLen int) int {
+	// version(8) + reads_count(4) + writes_count(4)
+	//   + one streamWrite: HashLength + 3 (24-bit keySize) + keyLen
+	//                      + 8 (64-bit dataSize) + dataLen
+	//   + acls_count(4)
+	return 8 + 4 + 4 + common.HashLength + 3 + keyLen + 8 + dataLen + 4
+}
+
 // Size returns the serialized data size in bytes.
 func (sd *StreamData) Size() int {
 	var size int

--- a/kv/types_test.go
+++ b/kv/types_test.go
@@ -1,0 +1,48 @@
+package kv
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestEncodedSizeForSingleWriteMatchesSize pins the closed-form helper
+// against the authoritative Size() method across a range of key/data
+// lengths. Both must agree, AND both must match the actual byte length
+// of Encode() — otherwise a pricing pre-flight built on the helper
+// would under-charge.
+func TestEncodedSizeForSingleWriteMatchesSize(t *testing.T) {
+	cases := []struct{ keyLen, dataLen int }{
+		{1, 1},
+		{1, 256},
+		{8, 0},
+		{16, 4096},
+		{32, 65536},
+		{64, 1 << 20},
+		{0xFFFF, 0xFFFF},
+	}
+	for _, tc := range cases {
+		sd := &StreamData{
+			Version: 0,
+			Writes: []streamWrite{{
+				StreamId: common.Hash{},
+				Key:      make([]byte, tc.keyLen),
+				Data:     make([]byte, tc.dataLen),
+			}},
+		}
+
+		want := sd.Size()
+		got := EncodedSizeForSingleWrite(tc.keyLen, tc.dataLen)
+		assert.Equal(t, want, got,
+			"helper drifted from Size(): keyLen=%d dataLen=%d", tc.keyLen, tc.dataLen)
+
+		// Belt-and-braces: actually encode and check the byte length.
+		// Size() promises encoded size, so this catches any bug where
+		// Size() itself drifts from Encode().
+		encoded, err := sd.Encode()
+		assert.NoError(t, err)
+		assert.Equal(t, want, len(encoded),
+			"Size() drifted from Encode(): keyLen=%d dataLen=%d", tc.keyLen, tc.dataLen)
+	}
+}


### PR DESCRIPTION
Closes #146.

## What

Cherry-picks two commits that sit on \`feat/s3-gateway-additions\` but never reached \`main\` after #138 was squash-merged:

  - \`c932f5a kv: add EncodedSizeForSingleWrite helper for preflight pricing\`
  - \`039b5b1 kv: test EncodedSizeForSingleWrite matches Size() and Encode()\`

## Why

\`EncodedSizeForSingleWrite(keyLen, dataLen)\` returns the exact byte count that \`(*StreamData).Encode()\` would produce for a stream-data blob with exactly one \`streamWrite\` (no reads, no ACLs) — the shape every gateway-side KV submit uses. Lets a caller price storage cost from the (key, data) lengths it will submit, *before* building the bytes.

\`0g-storage-s3-server\` imports this helper in \`services/preflight_kv.go\` for PUT / COPY / DELETE storage-fee reservation. Without it on main, that build fails:

\`\`\`
services/preflight_kv.go:75:18: undefined: kv.EncodedSizeForSingleWrite
services/preflight_kv.go:90:18: undefined: kv.EncodedSizeForSingleWrite
\`\`\`

Today the failure is masked by a local \`replace\` directive pointing the s3-server's \`go.mod\` at a feat-branch checkout. Tagged-release builds of the gateway against SDK main would not compile.

## Test plan

- [x] \`go build ./...\` clean against \`origin/main\` + these two commits
- [x] \`go vet ./...\` clean
- [x] \`go test ./kv/...\` green (\`TestEncodedSizeForSingleWriteMatchesSize\` constructs a real one-write \`StreamData\`, calls \`.Encode()\`, asserts \`len(encoded) == EncodedSizeForSingleWrite(keyLen, dataLen)\` — so the formula can't drift from \`Size()\` without the test breaking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)