### PR TITLE
transfer: surface Flow.submit txHash on segment-upload error (closes #148)

### DIFF
--- a/transfer/uploader.go
+++ b/transfer/uploader.go
@@ -235,11 +235,19 @@ func (uploader *Uploader) SplitableUpload(ctx context.Context, data core.Iterabl
 	rootHashes := make([]common.Hash, 0)
 	if data.Size() <= fragmentSize {
 		txHash, rootHash, err := uploader.uploadInner(ctx, data, opt)
+		// Surface the Flow.submit hash even on segment-upload failure
+		// so the retry wrapper in indexer/Client.SplitableUpload can
+		// see "submit already succeeded" and set opt.SkipTx = true
+		// on the next attempt. Otherwise the operator wallet pays
+		// Flow.submit again for the same content on every transient
+		// segment-upload retry. See #148.
+		if (txHash != common.Hash{}) {
+			txHashes = append(txHashes, txHash)
+			rootHashes = append(rootHashes, rootHash)
+		}
 		if err != nil {
 			return txHashes, rootHashes, err
 		}
-		txHashes = append(txHashes, txHash)
-		rootHashes = append(rootHashes, rootHash)
 	} else {
 		totalSize := data.Size()
 		fragments := data.Split(fragmentSize)
@@ -272,11 +280,16 @@ func (uploader *Uploader) SplitableUpload(ctx context.Context, data core.Iterabl
 				batchOpt.DataOptions = append(batchOpt.DataOptions, opt)
 			}
 			txHash, roots, err := uploader.BatchUpload(ctx, fragments[l:r], batchOpt)
+			// Same partial-progress logic as the single-fragment
+			// branch: surface a non-zero batch txHash on error so
+			// the retry wrapper can skip a re-submit. See #148.
+			if (txHash != common.Hash{}) {
+				txHashes = append(txHashes, txHash)
+				rootHashes = append(rootHashes, roots...)
+			}
 			if err != nil {
 				return txHashes, rootHashes, err
 			}
-			txHashes = append(txHashes, txHash)
-			rootHashes = append(rootHashes, roots...)
 		}
 	}
 	return txHashes, rootHashes, nil


### PR DESCRIPTION
Closes #148.

## What

\`(*Uploader).SplitableUpload\` early-returned with an empty \`txHashes\` slice when \`uploadInner\` errored — even when \`uploadInner\` had already returned a non-zero Flow.submit hash from a successful submit followed by a failed segment upload. That defeated the retry-skip-tx logic in \`indexer/Client.SplitableUpload\` (#145), which keys off \`len(txHashes) > 0\` to know \"previous attempt's submit succeeded, set \`opt.SkipTx = true\` on retry\".

## Fix

Append \`txHash\` to \`txHashes\` (and \`rootHash\` to \`rootHashes\`) **before** the early-return on error, when \`txHash\` is non-zero. Same shape in the multi-fragment branch's batch loop. ~17 lines including comments.

## Why

Observed today via the \`0g-storage-s3\` testnet smoke. With #145 already merged, a 1 MiB PUT still produced **two** distinct \`Flow.submit\` txs on a segment-upload flake:

  - \`0x6864869be0df0600b64cca4beb81744c0ff3c2d912bd5185ecbe7916e3aa8c13\` (block 35516775) — first attempt
  - \`0xb0ddce7b5ade8634f07beee1141fdd7b3d1257c451177f770a2b940bfd102a4a\` — retry, msg.value = 141,620,635,984,896 wei again

\`Client.SplitableUpload\`'s retry sees \`txHashes == []\` (this bug) → doesn't set \`opt.SkipTx = true\` → \`uploader.SplitableUpload\` re-submits Flow.submit. Same operator-wallet leak #145 was supposed to fix.

## Test plan

- [x] \`go build ./...\` + \`go vet ./...\` clean against \`origin/main\`
- [x] \`go test ./transfer/...\` green
- [ ] Re-run the 0g-storage-s3 large-file testnet smoke (1 MiB+1 body). On a segment-upload flake, expect exactly **one** Flow.submit tx, not two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)