### PR TITLE
transfer: SkipTx=true waits for log entry, doesn't fall back to re-submit (closes #150)

### DIFF
--- a/transfer/uploader.go
+++ b/transfer/uploader.go
@@ -373,12 +373,23 @@ func (uploader *Uploader) uploadInner(ctx context.Context, data core.IterableDat
 
 func (uploader *Uploader) uploadFast(ctx context.Context, data core.IterableData, tree *merkle.Tree, info *node.FileInfo, opt UploadOption, stageTimer time.Time) (common.Hash, common.Hash, error) {
 	txHash := common.Hash{}
-	if !opt.SkipTx || info == nil {
+	if !opt.SkipTx {
 		uploader.logger.WithField("root", tree.Root()).Info("Prepare to submit log entry")
 		var err error
 		txHash, err = uploader.submitLogEntryNoReceipt(ctx, data, opt)
 		if err != nil {
 			return txHash, tree.Root(), err
+		}
+	} else if info == nil {
+		// SkipTx asserts the entry IS on chain; the new uploader's
+		// storage nodes just haven't synced yet. Wait for them
+		// instead of falling back to a re-submit (which would charge
+		// the caller's wallet a second time). See #150.
+		uploader.logger.WithField("root", tree.Root()).Info("SkipTx=true; waiting for log entry on storage node before upload")
+		var err error
+		info, err = uploader.waitForLogEntry(ctx, tree.Root(), TransactionPacked, 0, false)
+		if err != nil {
+			return txHash, tree.Root(), errors.WithMessage(err, "SkipTx=true but log entry never appeared on storage node")
 		}
 	}
 
@@ -439,7 +450,7 @@ func (uploader *Uploader) uploadFast(ctx context.Context, data core.IterableData
 
 func (uploader *Uploader) uploadSlow(ctx context.Context, data core.IterableData, tree *merkle.Tree, info *node.FileInfo, opt UploadOption, stageTimer time.Time) (common.Hash, common.Hash, error) {
 	txHash := common.Hash{}
-	if !opt.SkipTx || info == nil {
+	if !opt.SkipTx {
 		if data.Size() <= slowParallelMaxSize && info == nil {
 			uploader.logger.WithField("root", tree.Root()).Info("Upload/Transaction in parallel")
 			txHash, err := uploader.uploadSlowParallel(ctx, data, tree, opt)
@@ -455,6 +466,17 @@ func (uploader *Uploader) uploadSlow(ctx context.Context, data core.IterableData
 		txHash, info, err = uploader.submitLogEntryAndWait(ctx, data, tree, opt)
 		if err != nil {
 			return txHash, tree.Root(), err
+		}
+	} else if info == nil {
+		// SkipTx asserts the entry IS on chain; the new uploader's
+		// storage nodes just haven't synced yet. Wait for them
+		// instead of falling back to a re-submit (which would charge
+		// the caller's wallet a second time). See #150.
+		uploader.logger.WithField("root", tree.Root()).Info("SkipTx=true; waiting for log entry on storage node before upload")
+		var err error
+		info, err = uploader.waitForLogEntry(ctx, tree.Root(), TransactionPacked, 0, false)
+		if err != nil {
+			return txHash, tree.Root(), errors.WithMessage(err, "SkipTx=true but log entry never appeared on storage node")
 		}
 	}
 


### PR DESCRIPTION
Closes #150.

## What

After #145 + #149, \`Client.SplitableUpload\`'s retry correctly sets \`opt.SkipTx = true\` when the previous attempt landed a Flow.submit. But \`uploadSlow\` / \`uploadFast\` gate the skip on \`checkLogExistence\` returning non-nil \`info\` — and on retry, the new \`Uploader\` is built against fresh storage nodes from the indexer that may not have synced the previous submit yet. \`info == nil\` → fresh \`Flow.submit\` despite \`SkipTx=true\` → operator wallet pays twice.

## Fix

Split the conditional so \`SkipTx=true\` means "the caller asserts the entry is on chain; wait for storage nodes to see it; do NOT re-submit." When \`info == nil\` under \`SkipTx=true\`, \`waitForLogEntry\` instead of falling back to submit. Same change in both branches.

\`\`\`go
if !opt.SkipTx {
    // submit
} else if info == nil {
    info, err = waitForLogEntry(ctx, tree.Root(), TransactionPacked, 0, false)
    if err != nil {
        return ..., \"SkipTx=true but log entry never appeared on storage node\"
    }
}
\`\`\`

## Behavior change for callers

A caller passing \`SkipTx=true\` when the entry is NOT actually on chain used to fall back to a fresh submit; with this fix they would wait until ctx timeout. That's correct — \`SkipTx\` is a deliberate caller assertion that the entry exists. Silent re-submit was always a bug surface (operator wallet pays for a duplicate). The \`0g-storage-s3\` gateway, the main consumer of this SDK today, uses \`SkipTx\` exactly this way:

  - Crash-resume from a recorded prior \`flow_submit_attempts\` row
  - Retry inside \`Client.SplitableUpload\` after a previous attempt's submit succeeded (#145)

## Test plan

- [x] \`go build ./...\` + \`go vet ./...\` clean against \`origin/main\`
- [x] \`go test ./transfer/...\` green
- [ ] Re-run the s3-gateway's full-op + large-file testnet smokes — segment-upload retries should now land exactly one Flow.submit even if the new uploader's nodes haven't synced

🤖 Generated with [Claude Code](https://claude.com/claude-code)