### PR TITLE
fix(indexer): preserve landed Flow.submit tx hash across SkipTx retries (#157)

### DIFF
--- a/indexer/client.go
+++ b/indexer/client.go
@@ -151,6 +151,12 @@ func (c *Client) SplitableUpload(ctx context.Context, w3Client *web3go.Client, d
 
 	dropped := make([]string, 0)
 	attempts := 0
+	// Preserve the landed Flow.submit across SkipTx-recovery: once a
+	// submit lands (non-zero tx), a later recovering iteration uploads
+	// the segments but returns a zero (skipped) tx hash. We must still
+	// surface the real submission so callers can record/bill it instead
+	// of mistaking it for a no-op dedup. See #157.
+	var landedTx, landedRoots []eth_common.Hash
 
 	for {
 		uploader, err := c.NewUploaderFromIndexerNodes(ctx, data.NumSegments(), w3Client, expectedReplica, dropped, opt.Method, opt.FullTrusted)
@@ -159,8 +165,14 @@ func (c *Client) SplitableUpload(ctx context.Context, w3Client *web3go.Client, d
 		}
 
 		txHashes, roots, err := uploader.SplitableUpload(ctx, data, opt)
+		// Remember the first iteration that actually submitted, so a
+		// later SkipTx-recovery iteration's zero hash can't erase it.
+		if len(landedTx) == 0 && anyNonZero(txHashes) {
+			landedTx, landedRoots = txHashes, roots
+		}
 		if err == nil {
-			return txHashes, roots, nil
+			rtx, rroots := preferLanded(txHashes, roots, landedTx, landedRoots)
+			return rtx, rroots, nil
 		}
 
 		// If Flow.submit already succeeded on a previous attempt
@@ -193,9 +205,34 @@ func (c *Client) SplitableUpload(ctx context.Context, w3Client *web3go.Client, d
 		}
 
 		if attempts >= maxRetry {
-			return txHashes, roots, err
+			rtx, rroots := preferLanded(txHashes, roots, landedTx, landedRoots)
+			return rtx, rroots, err
 		}
 	}
+}
+
+// anyNonZero reports whether hs contains at least one non-zero hash —
+// i.e. an actual on-chain submission (as opposed to a skipped/zero one).
+func anyNonZero(hs []eth_common.Hash) bool {
+	for _, h := range hs {
+		if h != (eth_common.Hash{}) {
+			return true
+		}
+	}
+	return false
+}
+
+// preferLanded returns the landed submission (txHashes+roots captured on
+// an earlier retry iteration) when the current iteration skipped it (all
+// hashes zero). This preserves the real Flow.submit across SkipTx-
+// recovery so callers can record/bill it. When no submit ever landed
+// (genuine pre-existing dedup, zero throughout), the current zero result
+// is returned unchanged. See #157.
+func preferLanded(curTx, curRoots, landedTx, landedRoots []eth_common.Hash) ([]eth_common.Hash, []eth_common.Hash) {
+	if len(landedTx) > 0 && !anyNonZero(curTx) {
+		return landedTx, landedRoots
+	}
+	return curTx, curRoots
 }
 
 // BatchUpload submit multiple data to 0g storage contract batchly in single on-chain transaction, then transfer the data to the storage nodes selected from indexer service.

--- a/indexer/splitable_upload_landed_test.go
+++ b/indexer/splitable_upload_landed_test.go
@@ -1,0 +1,85 @@
+package indexer
+
+import (
+	"testing"
+
+	eth_common "github.com/ethereum/go-ethereum/common"
+)
+
+func nz(b byte) eth_common.Hash { // non-zero hash with a distinguishing byte
+	var x eth_common.Hash
+	x[31] = b
+	return x
+}
+
+var zeroHash = eth_common.Hash{}
+
+func eqHashes(a, b []eth_common.Hash) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestAnyNonZero(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []eth_common.Hash
+		want bool
+	}{
+		{"nil", nil, false},
+		{"empty", []eth_common.Hash{}, false},
+		{"one-zero", []eth_common.Hash{zeroHash}, false},
+		{"two-zero", []eth_common.Hash{zeroHash, zeroHash}, false},
+		{"one-nonzero", []eth_common.Hash{nz(1)}, true},
+		{"mixed", []eth_common.Hash{zeroHash, nz(2)}, true},
+	}
+	for _, c := range cases {
+		if got := anyNonZero(c.in); got != c.want {
+			t.Errorf("%s: anyNonZero(%v) = %v, want %v", c.name, c.in, got, c.want)
+		}
+	}
+}
+
+func TestPreferLanded(t *testing.T) {
+	landedTx := []eth_common.Hash{nz(1)}
+	landedRoots := []eth_common.Hash{nz(10)}
+
+	t.Run("recovery skip returns landed tx", func(t *testing.T) {
+		// Submit landed on an earlier iteration; the recovering iteration
+		// skipped (all-zero tx). Must surface the landed tx, not the zero.
+		gotTx, gotRoots := preferLanded([]eth_common.Hash{zeroHash}, []eth_common.Hash{nz(10)}, landedTx, landedRoots)
+		if !eqHashes(gotTx, landedTx) {
+			t.Errorf("tx = %v, want landed %v", gotTx, landedTx)
+		}
+		if !eqHashes(gotRoots, landedRoots) {
+			t.Errorf("roots = %v, want landed %v", gotRoots, landedRoots)
+		}
+	})
+
+	t.Run("current iteration landed returns current", func(t *testing.T) {
+		curTx := []eth_common.Hash{nz(2)}
+		curRoots := []eth_common.Hash{nz(20)}
+		gotTx, gotRoots := preferLanded(curTx, curRoots, landedTx, landedRoots)
+		if !eqHashes(gotTx, curTx) {
+			t.Errorf("tx = %v, want current %v", gotTx, curTx)
+		}
+		if !eqHashes(gotRoots, curRoots) {
+			t.Errorf("roots = %v, want current %v", gotRoots, curRoots)
+		}
+	})
+
+	t.Run("no landed ever returns current (pre-existing dedup stays zero)", func(t *testing.T) {
+		// True dedup: skipped from the first attempt, no submit ever.
+		// Must keep returning the zero so the caller refunds, not bills.
+		gotTx, _ := preferLanded([]eth_common.Hash{zeroHash}, []eth_common.Hash{nz(10)}, nil, nil)
+		if anyNonZero(gotTx) {
+			t.Errorf("tx = %v, want all-zero (no landed submit)", gotTx)
+		}
+	})
+}


### PR DESCRIPTION
Closes #157.

## Problem
`indexer.Client.SplitableUpload` retries internally. If Flow.submit lands on one iteration but the segment upload fails, it sets `opt.SkipTx=true` and retries. On the **recovering** iteration the upload succeeds, but `uploader.SplitableUpload` returns the **zero** (skipped) tx hash — and the wrapper returned *that* iteration's result, dropping the landed tx hash.

A caller that recovers via the internal retry therefore gets back a zero tx hash for content actually submitted + paid on chain, and can't distinguish "we paid earlier" from "genuine pre-existing dedup." (Downstream, the 0g-storage-s3 gateway records `storage_fee=0` → silently absorbs the file cost on any post-submit upload retry — see 0gfoundation/0g-storage-s3-server#127.)

## Fix
Track the first iteration that actually submitted (non-zero tx) and return it on eventual success and on final error, unless the current iteration itself submitted. Genuine pre-existing dedup (zero throughout) still returns zero, so existing caller refund/no-op behavior is unchanged.

Superset of #148/#155 — same intent (surface the real on-chain submission), extended to the recover-then-succeed path.

## Tests
The retry loop needs live nodes, so the decision is extracted into pure helpers (`anyNonZero`, `preferLanded`) with deterministic unit tests covering: recovery-skip → returns landed; current-iteration-landed → returns current; never-landed (pre-existing dedup) → stays zero. `go test ./indexer/` green; full `go build ./...` green.