### PR TITLE
transfer/contract: surface broadcast tx hash via OnSubmitted callback (#159)

### DIFF
--- a/contract/contract.go
+++ b/contract/contract.go
@@ -132,11 +132,21 @@ func (submission Submission) Root() common.Hash {
 	return root
 }
 
+// onBroadcast, if non-nil, is invoked with the transaction hash the
+// instant each Flow.submit broadcasts — before the receipt wait. It is
+// the single point where the hash first exists, so a caller can journal
+// the spend durably the moment it happens; a crash or caller-abort before
+// this function returns then can't lose the hash. The receipt wait itself
+// is intentionally NOT cancellable by the caller's context (see the ctx
+// note below). Fires per successful Transact; under gas-bump retries it
+// can fire more than once (replacement txs share a nonce, so at most one
+// mines — callers that accumulate hashes must resolve each on chain).
 func TransactWithGasAdjustment(
 	contract *FlowContract,
 	method string,
 	opts *bind.TransactOpts,
 	retryOpts *TxRetryOption,
+	onBroadcast func(common.Hash),
 	params ...any,
 ) (*types.Receipt, error) {
 	// Set timeout and max non-gas retries from retryOpts if provided.
@@ -189,6 +199,13 @@ func TransactWithGasAdjustment(
 	errCh := make(chan error, 1)
 	failCh := make(chan error, 1)
 
+	// The receipt wait runs on a fresh context, deliberately NOT derived
+	// from opts.Context: once the tx is broadcast the operator has paid
+	// and the receipt is imminent, so a caller cancel (e.g. a drain) must
+	// NOT abandon the wait — that would discard the receipt (and its seq
+	// mapping) for a tx that is going to mine anyway. The caller learns the
+	// hash at broadcast via onBroadcast; the long-pole segment upload that
+	// follows is what honors the caller's context. See issue #159.
 	var ctx context.Context
 	var cancel context.CancelFunc
 	if retryOpts.Timeout > 0 {
@@ -221,6 +238,13 @@ func TransactWithGasAdjustment(
 			tx, err := contract.FlowTransactor.contract.Transact(opts, method, params...)
 
 			if err == nil {
+				// The tx is broadcast: surface its hash NOW, the instant it
+				// exists and before the receipt wait. This is the durable
+				// record of the spend — a crash or caller-abort before this
+				// function returns can't lose it. See issue #159.
+				if onBroadcast != nil {
+					onBroadcast(tx.Hash())
+				}
 				// Wait for successful execution in a separate goroutine.
 				// Use local variables to avoid racing with the outer loop's err.
 				go func() {
@@ -300,6 +324,7 @@ func TransactWithGasAdjustmentNoReceipt(
 	method string,
 	opts *bind.TransactOpts,
 	retryOpts *TxRetryOption,
+	onBroadcast func(common.Hash),
 	params ...any,
 ) (*types.Transaction, error) {
 	// Set timeout and max non-gas retries from retryOpts if provided.
@@ -336,6 +361,9 @@ func TransactWithGasAdjustmentNoReceipt(
 
 		tx, err := contract.FlowTransactor.contract.Transact(opts, method, params...)
 		if err == nil {
+			if onBroadcast != nil {
+				onBroadcast(tx.Hash())
+			}
 			return tx, nil
 		}
 

--- a/tests/context_callback_test.py
+++ b/tests/context_callback_test.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+import os
+
+from client_test_framework.test_framework import ClientTestFramework
+from config.node_config import GENESIS_PRIV_KEY
+from client_utility.run_go_test import run_go_test
+
+
+class ContextCallbackTest(ClientTestFramework):
+    """E2E for issue #159 — the OnSubmitted broadcast callback + caller-
+    context awareness in the upload submit path:
+
+      1. no_receipt   — small upload, no-receipt path: callback fires once
+                        at broadcast with the returned hash.
+      2. wait_receipt — >2MiB upload, receipt-wait path: same contract.
+      3. cancel_preserves_hash — cancel the instant the tx broadcasts; the
+                        upload aborts and returns no hash, but the callback
+                        captured the broadcast hash and the tx is on chain.
+    """
+
+    def setup_params(self):
+        self.num_blockchain_nodes = 1
+        self.num_nodes = 1
+        # Single non-sharded node sized to hold the 3MiB case comfortably.
+        self.zgs_node_configs[0] = {
+            "db_max_num_sectors": 2**30,
+        }
+
+    def run_test(self):
+        test_args = [
+            "go",
+            "run",
+            os.path.join(
+                os.path.dirname(__file__), "go_tests", "context_callback_test", "main.go"
+            ),
+            GENESIS_PRIV_KEY,
+            self.blockchain_nodes[0].rpc_url,
+            ",".join([x.rpc_url for x in self.nodes]),
+        ]
+        run_go_test(self.root_dir, test_args)
+
+
+if __name__ == "__main__":
+    ContextCallbackTest().main()

--- a/tests/go_tests/context_callback_test/main.go
+++ b/tests/go_tests/context_callback_test/main.go
@@ -1,0 +1,230 @@
+package main
+
+// E2E for issue #159: the OnSubmitted broadcast callback + caller-context
+// awareness in the upload submit path.
+//
+// Three cases, all against a real local chain + storage node:
+//
+//  1. wait_receipt   — a >2MiB upload takes the receipt-wait path
+//                      (uploadSlow → submitLogEntryAndWait →
+//                      TransactWithGasAdjustment). OnSubmitted must fire
+//                      once, at broadcast, with the SAME hash the upload
+//                      ultimately returns.
+//  2. no_receipt     — a small upload takes the no-receipt path
+//                      (uploadSlowParallel → TransactWithGasAdjustmentNoReceipt).
+//                      Same contract: OnSubmitted fires once with the
+//                      returned hash.
+//  3. cancel_preserves_hash — the caller cancels the instant the tx
+//                      broadcasts (cancel() invoked from inside
+//                      OnSubmitted). This models a drain firing mid-upload.
+//                      Asserts the corrected design:
+//                        * the upload returns an error (the long-pole
+//                          segment upload honors the cancel and aborts), AND
+//                        * the broadcast callback captured the on-chain
+//                          hash, AND
+//                        * the receipt wait was NOT terminated by the
+//                          cancel — proven by the return STILL carrying the
+//                          same tx hash (the wait ran on its own context to
+//                          completion). That last assertion is the
+//                          regression guard for "don't terminate the wait;
+//                          we just want the hash" (issue #159).
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"math/rand"
+	"os"
+	"strings"
+	"time"
+
+	zgcommon "github.com/0gfoundation/0g-storage-client/common"
+	"github.com/0gfoundation/0g-storage-client/common/blockchain"
+	"github.com/0gfoundation/0g-storage-client/common/util"
+	"github.com/0gfoundation/0g-storage-client/core"
+	"github.com/0gfoundation/0g-storage-client/transfer"
+	ethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/openweb3/web3go"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+func randomBytes(length int) ([]byte, error) {
+	b := make([]byte, length)
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	if _, err := io.ReadFull(r, b); err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+func newUploader(ctx context.Context, w3 *web3go.Client, nodeUrls []string) (*transfer.Uploader, func(), error) {
+	return transfer.NewUploaderFromConfig(ctx, w3, transfer.UploaderConfig{
+		Nodes:     nodeUrls,
+		LogOption: zgcommon.LogOption{Logger: logrus.StandardLogger()},
+	})
+}
+
+// caseCallbackFires uploads `size` bytes and asserts OnSubmitted fired
+// exactly once, at broadcast, with the same non-zero hash the upload
+// returns. Covers both submit paths via the size (small → no-receipt,
+// large → receipt-wait).
+func caseCallbackFires(ctx context.Context, w3 *web3go.Client, nodeUrls []string, name string, size int) error {
+	logrus.Infof("=== %s (size=%d) ===", name, size)
+
+	data, err := randomBytes(size)
+	if err != nil {
+		return errors.WithMessagef(err, "%s: random bytes", name)
+	}
+	iter, err := core.NewDataInMemory(data)
+	if err != nil {
+		return errors.WithMessagef(err, "%s: NewDataInMemory", name)
+	}
+
+	uploader, closer, err := newUploader(ctx, w3, nodeUrls)
+	if err != nil {
+		return errors.WithMessagef(err, "%s: NewUploaderFromConfig", name)
+	}
+	defer closer()
+
+	var broadcast []ethcommon.Hash
+	opt := transfer.UploadOption{
+		FinalityRequired: transfer.FileFinalized,
+		TransactionOption: transfer.TransactionOption{
+			OnSubmitted: func(h ethcommon.Hash) { broadcast = append(broadcast, h) },
+		},
+	}
+
+	txHashes, _, err := uploader.SplitableUpload(ctx, iter, opt)
+	if err != nil {
+		return errors.WithMessagef(err, "%s: SplitableUpload", name)
+	}
+
+	if len(broadcast) != 1 {
+		return fmt.Errorf("%s: OnSubmitted fired %d times, want exactly 1 (single fragment, single tx)", name, len(broadcast))
+	}
+	if (broadcast[0] == ethcommon.Hash{}) {
+		return fmt.Errorf("%s: OnSubmitted got the zero hash", name)
+	}
+	if len(txHashes) != 1 || txHashes[0] != broadcast[0] {
+		return fmt.Errorf("%s: broadcast hash %s != returned hash %v", name, broadcast[0].Hex(), txHashes)
+	}
+	logrus.Infof("%s: PASSED — OnSubmitted fired once at broadcast with %s (== returned hash)", name, broadcast[0].Hex())
+	return nil
+}
+
+// caseCancelPreservesHash cancels from inside OnSubmitted (the instant the
+// tx broadcasts) and proves the broadcast hash is preserved via the
+// callback even though the cancelled upload returns no hash, and that the
+// tx really landed on chain.
+func caseCancelPreservesHash(parent context.Context, w3 *web3go.Client, nodeUrls []string) error {
+	const name = "cancel_preserves_hash"
+	logrus.Infof("=== %s ===", name)
+
+	data, err := randomBytes(3 * 1024 * 1024) // >2MiB → receipt-wait path
+	if err != nil {
+		return errors.WithMessagef(err, "%s: random bytes", name)
+	}
+	iter, err := core.NewDataInMemory(data)
+	if err != nil {
+		return errors.WithMessagef(err, "%s: NewDataInMemory", name)
+	}
+
+	ctx, cancel := context.WithCancel(parent)
+	defer cancel()
+
+	uploader, closer, err := newUploader(ctx, w3, nodeUrls)
+	if err != nil {
+		return errors.WithMessagef(err, "%s: NewUploaderFromConfig", name)
+	}
+	defer closer()
+
+	var captured ethcommon.Hash
+	opt := transfer.UploadOption{
+		FinalityRequired: transfer.FileFinalized,
+		TransactionOption: transfer.TransactionOption{
+			OnSubmitted: func(h ethcommon.Hash) {
+				captured = h
+				cancel() // drain fired the instant the tx broadcast
+			},
+		},
+	}
+
+	start := time.Now()
+	txHashes, _, err := uploader.SplitableUpload(ctx, iter, opt)
+	elapsed := time.Since(start)
+
+	// The upload must NOT succeed — the long-pole segment upload honors
+	// the cancel and aborts.
+	if err == nil {
+		return fmt.Errorf("%s: SplitableUpload returned nil error despite cancel-at-broadcast", name)
+	}
+	logrus.Infof("%s: upload aborted after %s with: %v", name, elapsed, err)
+
+	// The callback must have captured the real broadcast hash.
+	if (captured == ethcommon.Hash{}) {
+		return fmt.Errorf("%s: OnSubmitted never captured a hash — record-at-broadcast failed", name)
+	}
+
+	// Regression guard for "don't terminate the receipt wait" (#159): the
+	// receipt wait ran on its own context to completion despite the cancel,
+	// so the upload's RETURN must STILL carry the same broadcast hash. If a
+	// future change made the wait honor the caller's context, the wait
+	// would abort with a nil receipt and the return would drop the hash —
+	// this assertion would then fail.
+	if len(txHashes) != 1 || txHashes[0] != captured {
+		return fmt.Errorf("%s: receipt wait was terminated by cancel — return hash %v != broadcast hash %s (the wait must complete; see #159)",
+			name, txHashes, captured.Hex())
+	}
+
+	// And that tx must actually be on chain: the operator paid for it, so
+	// the caller can resolve + bill it on resume.
+	verifyCtx := context.Background()
+	found := false
+	for i := 0; i < 30; i++ {
+		tx, terr := w3.Eth.TransactionByHash(captured)
+		if terr == nil && tx != nil {
+			found = true
+			break
+		}
+		select {
+		case <-verifyCtx.Done():
+			return verifyCtx.Err()
+		case <-time.After(time.Second):
+		}
+	}
+	if !found {
+		return fmt.Errorf("%s: captured broadcast hash %s not found on chain", name, captured.Hex())
+	}
+
+	logrus.Infof("%s: PASSED — cancel-at-broadcast preserved %s via callback; tx is on chain", name, captured.Hex())
+	return nil
+}
+
+func runTest() error {
+	ctx := context.Background()
+	args := os.Args[1:]
+	key := args[0]
+	chainURL := args[1]
+	nodeUrls := strings.Split(args[2], ",")
+
+	w3 := blockchain.MustNewWeb3(chainURL, key)
+	defer w3.Close()
+
+	if err := caseCallbackFires(ctx, w3, nodeUrls, "no_receipt", 100*1024); err != nil {
+		return err
+	}
+	if err := caseCallbackFires(ctx, w3, nodeUrls, "wait_receipt", 3*1024*1024); err != nil {
+		return err
+	}
+	if err := caseCancelPreservesHash(ctx, w3, nodeUrls); err != nil {
+		return err
+	}
+	return nil
+}
+
+func main() {
+	if err := util.WaitUntil(runTest, time.Minute*5); err != nil {
+		logrus.WithError(err).Fatalf("context callback test failed")
+	}
+}

--- a/transfer/context_callback_test.go
+++ b/transfer/context_callback_test.go
@@ -1,0 +1,86 @@
+package transfer
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The OnSubmitted broadcast callback (issue #159) rides on the embedded
+// TransactionOption so it threads automatically from the public option
+// structs (UploadOption / BatchUploadOption) down to the
+// SubmitLogEntryOption that SubmitLogEntry actually passes to the
+// contract layer. A refactor that reconstructs any of these structs
+// field-by-field (or moves OnSubmitted off the embedded type) would
+// silently drop the callback — and a dropped callback re-opens the
+// landed-but-unrecorded window on cancel with NO behavioral test
+// failure (the upload still succeeds; only crash-resume billing breaks).
+// These tests pin the threading so that silent-failure mode can't ship.
+
+// fires returns a callback plus a pointer to the hash it captures, so a
+// test can prove the SAME callback survived a struct copy by invoking it
+// (func values are not == comparable in Go beyond nil).
+func fires() (func(common.Hash), *common.Hash) {
+	var got common.Hash
+	return func(h common.Hash) { got = h }, &got
+}
+
+func TestOnSubmitted_PreservedThroughNormalizeUpload(t *testing.T) {
+	cb, got := fires()
+	opt := UploadOption{TransactionOption: TransactionOption{OnSubmitted: cb}}
+
+	normalizeUploadOption(&opt)
+
+	require.NotNil(t, opt.OnSubmitted, "normalizeUploadOption dropped OnSubmitted")
+	want := common.HexToHash("0xabc123")
+	opt.OnSubmitted(want)
+	assert.Equal(t, want, *got, "OnSubmitted after normalize is not the original callback")
+}
+
+// Mirrors the construction in submitLogEntryNoReceipt / submitLogEntryAndWait:
+// SubmitLogEntryOption{TransactionOption: opt.TransactionOption, ...}.
+func TestOnSubmitted_ThreadsToSubmitLogEntryOption(t *testing.T) {
+	cb, got := fires()
+	opt := UploadOption{TransactionOption: TransactionOption{OnSubmitted: cb}}
+
+	submitOpts := SubmitLogEntryOption{TransactionOption: opt.TransactionOption}
+
+	require.NotNil(t, submitOpts.OnSubmitted, "OnSubmitted did not thread into SubmitLogEntryOption")
+	want := common.HexToHash("0xdeadbeef")
+	submitOpts.OnSubmitted(want)
+	assert.Equal(t, want, *got)
+}
+
+// Mirrors the batch path in SplitableUpload: txOpt := opt.TransactionOption;
+// txOpt.Nonce = nil; batchOpt := BatchUploadOption{TransactionOption: txOpt}.
+// Then BatchUpload builds its SubmitLogEntryOption from opts.TransactionOption.
+func TestOnSubmitted_ThreadsThroughBatchToSubmitLogEntry(t *testing.T) {
+	cb, got := fires()
+	opt := UploadOption{TransactionOption: TransactionOption{OnSubmitted: cb}}
+
+	txOpt := opt.TransactionOption
+	txOpt.Nonce = nil // as SplitableUpload does per batch
+	batchOpt := BatchUploadOption{TransactionOption: txOpt}
+
+	// BatchUpload's inner construction.
+	submitOpt := SubmitLogEntryOption{TransactionOption: batchOpt.TransactionOption}
+
+	require.NotNil(t, submitOpt.OnSubmitted, "OnSubmitted did not survive UploadOption→batch→SubmitLogEntryOption")
+	want := common.HexToHash("0xfeed")
+	submitOpt.OnSubmitted(want)
+	assert.Equal(t, want, *got)
+}
+
+func TestOnSubmitted_NilByDefault(t *testing.T) {
+	// Existing callers that never set it must keep a nil callback — the
+	// contract layer nil-guards before invoking, so this is the
+	// no-behavior-change baseline.
+	var opt UploadOption
+	normalizeUploadOption(&opt)
+	assert.Nil(t, opt.OnSubmitted)
+
+	submitOpts := SubmitLogEntryOption{TransactionOption: opt.TransactionOption}
+	assert.Nil(t, submitOpts.OnSubmitted)
+}

--- a/transfer/extend.go
+++ b/transfer/extend.go
@@ -220,7 +220,7 @@ func (uploader *Uploader) Resubmit(ctx context.Context, items []ExtendItem, opt 
 			params = []any{subs[0]}
 		}
 
-		receipt, err := contract.TransactWithGasAdjustment(uploader.flow, method, opts, retryOpt, params...)
+		receipt, err := contract.TransactWithGasAdjustment(uploader.flow, method, opts, retryOpt, opt.OnSubmitted, params...)
 		if err != nil {
 			return txHashes, errors.WithMessage(err, "Failed to re-submit for extend")
 		}

--- a/transfer/uploader.go
+++ b/transfer/uploader.go
@@ -54,6 +54,17 @@ type TransactionOption struct {
 	MaxGasPrice *big.Int       // max gas price for transaction
 	NRetries    int            // number of retries for uploading
 	Step        int64          // step for gas price increase (step/10, e.g. 15 means 1.5x)
+
+	// OnSubmitted, if non-nil, is invoked with the transaction hash the
+	// instant each Flow.submit broadcasts — BEFORE the receipt wait and
+	// segment upload. It fires once per Flow.submit (a multi-batch upload
+	// calls it once per batch), at the single point where the hash first
+	// exists. It lets a caller durably journal "this tx was broadcast" so
+	// a context-cancel or crash between broadcast and the upload's return
+	// can't lose the hash and strand a paid submit. Must be cheap and
+	// non-blocking: it runs inline on the submit path. Additive — nil for
+	// existing callers, no behavior change.
+	OnSubmitted func(common.Hash)
 }
 
 // UploadOption upload option for a file
@@ -639,9 +650,9 @@ func (uploader *Uploader) SubmitLogEntry(ctx context.Context, datas []core.Itera
 	}
 
 	if waitReceipt {
-		receipt, err = contract.TransactWithGasAdjustment(uploader.flow, method, opts, retryOpt, params...)
+		receipt, err = contract.TransactWithGasAdjustment(uploader.flow, method, opts, retryOpt, submitOption.OnSubmitted, params...)
 	} else {
-		tx, err = contract.TransactWithGasAdjustmentNoReceipt(uploader.flow, method, opts, retryOpt, params...)
+		tx, err = contract.TransactWithGasAdjustmentNoReceipt(uploader.flow, method, opts, retryOpt, submitOption.OnSubmitted, params...)
 	}
 
 	if err != nil {


### PR DESCRIPTION
## Summary

Adds an additive `OnSubmitted func(common.Hash)` to `transfer.TransactionOption`, invoked **the instant each `Flow.submit` broadcasts** — before the receipt wait — at the single point where the hash first exists (right after `Transact` in both `TransactWithGasAdjustment` and `TransactWithGasAdjustmentNoReceipt`).

It threads automatically from `UploadOption` / `BatchUploadOption` / `SubmitLogEntryOption` through the embedded `TransactionOption`; `SubmitLogEntry` hands it down to the contract layer.

This lets a caller (the 0G S3 gateway) durably journal a paid submit the moment it happens, so a crash or graceful drain **between broadcast and the upload's return** can't lose the hash and strand the spend.

## Deliberately NOT cancelling the receipt wait

Once a tx is broadcast the operator has paid and the receipt is imminent, so aborting the wait on the caller's context would only discard the receipt (and its seq mapping) for a tx that mines anyway. The long-pole **segment upload** that follows already honors the caller's context (`parallel.Serial` → `work` selects on `ctx.Done()`), so a drain still aborts promptly there. The receipt-wait control flow is unchanged; nil callback → no behavior change for existing callers.

## Tests

- **Unit** (`transfer/context_callback_test.go`): pins that `OnSubmitted` survives every option-struct copy that feeds `SubmitLogEntry` — a silent-drop here would re-open the crash window with no behavioral failure.
- **E2E** (`tests/context_callback_test.py` + `tests/go_tests/context_callback_test/`), against a real local chain + storage node:
  - `no_receipt` / `wait_receipt`: callback fires exactly once with the same hash the upload returns, on both submit paths.
  - `cancel_preserves_hash`: cancelling at broadcast aborts the upload (segment upload honors the cancel) **yet** the callback captured the on-chain hash, **and** the return still carries the same hash — proving the receipt wait was not terminated (regression guard for the design above).

Verified: `go build ./...`, `go vet`, unit suite, and the new e2e all pass.

Closes #159